### PR TITLE
style: Setup Prettier for code formatting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,50 +1,42 @@
 {
-  "root": true,
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "ecmaVersion": 2022,
-    "sourceType": "module",
-    "project": "./tsconfig.json"
-  },
-  "plugins": [
-    "@typescript-eslint",
-    "import"
-  ],
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:import/recommended",
-    "plugin:import/typescript"
-  ],
-  "rules": {
-    "@typescript-eslint/consistent-type-imports": "error",
-    "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        "argsIgnorePattern": "^_",
-        "varsIgnorePattern": "^_"
-      }
+    "root": true,
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": 2022,
+        "sourceType": "module",
+        "project": "./tsconfig.json"
+    },
+    "plugins": ["@typescript-eslint", "import"],
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:import/recommended",
+        "plugin:import/typescript",
+        "prettier"
     ],
-    "no-console": "off"
-  },
-  "settings": {
-    "import/resolver": {
-      "typescript": {
-        "alwaysTryTypes": true,
-        "project": [
-          "tsconfig.json",
-          "apps/*/tsconfig.json",
-          "packages/*/tsconfig.json"
-        ]
-      }
-    }
-  },
-  "ignorePatterns": [
-    "node_modules/",
-    "dist/",
-    "build/",
-    "*.js",
-    "*.d.ts"
-  ]
+    "rules": {
+        "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/no-explicit-any": "error",
+        "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_"
+            }
+        ],
+        "no-console": "off"
+    },
+    "settings": {
+        "import/resolver": {
+            "typescript": {
+                "alwaysTryTypes": true,
+                "project": [
+                    "tsconfig.json",
+                    "apps/*/tsconfig.json",
+                    "packages/*/tsconfig.json"
+                ]
+            }
+        }
+    },
+    "ignorePatterns": ["node_modules/", "dist/", "build/", "*.js", "*.d.ts"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,28 @@
+# Dependencies
+node_modules/
+pnpm-lock.yaml
+package-lock.json
+
+# Build outputs
+dist/
+build/
+out/
+.next/
+
+# Generated files
+*.d.ts
+*.tsbuildinfo
+
+# Logs
+*.log
+
+# Coverage
+coverage/
+.nyc_output/
+
+# GitHub workflows
+.github/
+
+# IDE
+.vscode/
+.idea/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "semi": true,
+    "singleQuote": false,
+    "trailingComma": "es5",
+    "printWidth": 80,
+    "tabWidth": 4,
+    "useTabs": false,
+    "arrowParens": "always",
+    "endOfLine": "lf"
+}

--- a/apps/citadel/.eslintrc.json
+++ b/apps/citadel/.eslintrc.json
@@ -1,13 +1,13 @@
 {
-  "extends": "../../.eslintrc.json",
-  "rules": {
-    "import/extensions": [
-      "error",
-      "ignorePackages",
-      {
-        "js": "always",
-        "ts": "never"
-      }
-    ]
-  }
+    "extends": "../../.eslintrc.json",
+    "rules": {
+        "import/extensions": [
+            "error",
+            "ignorePackages",
+            {
+                "js": "always",
+                "ts": "never"
+            }
+        ]
+    }
 }

--- a/apps/citadel/nest-cli.json
+++ b/apps/citadel/nest-cli.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://json.schemastore.org/nest-cli",
-  "collection": "@nestjs/schematics",
-  "sourceRoot": "src",
-  "compilerOptions": {
-    "deleteOutDir": true,
-    "tsConfigPath": "tsconfig.json"
-  }
+    "$schema": "https://json.schemastore.org/nest-cli",
+    "collection": "@nestjs/schematics",
+    "sourceRoot": "src",
+    "compilerOptions": {
+        "deleteOutDir": true,
+        "tsConfigPath": "tsconfig.json"
+    }
 }

--- a/apps/citadel/package.json
+++ b/apps/citadel/package.json
@@ -1,29 +1,29 @@
 {
-  "name": "@forge/citadel",
-  "version": "0.0.0",
-  "private": true,
-  "description": "Telegram account management service",
-  "scripts": {
-    "dev": "nest start --watch",
-    "build": "nest build",
-    "start": "node dist/main.js",
-    "start:prod": "node dist/main.js",
-    "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
-  },
-  "dependencies": {
-    "@forge/shared": "workspace:*",
-    "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0",
-    "@nestjs/platform-fastify": "^10.0.0",
-    "fastify": "^4.0.0",
-    "reflect-metadata": "^0.2.0"
-  },
-  "devDependencies": {
-    "@nestjs/cli": "^10.4.9",
-    "@nestjs/schematics": "^10.0.0",
-    "@types/node": "^20.0.0",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.0.0"
-  }
+    "name": "@forge/citadel",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Telegram account management service",
+    "scripts": {
+        "dev": "nest start --watch",
+        "build": "nest build",
+        "start": "node dist/main.js",
+        "start:prod": "node dist/main.js",
+        "typecheck": "tsc --noEmit",
+        "clean": "rm -rf dist"
+    },
+    "dependencies": {
+        "@forge/shared": "workspace:*",
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/platform-fastify": "^10.0.0",
+        "fastify": "^4.0.0",
+        "reflect-metadata": "^0.2.0"
+    },
+    "devDependencies": {
+        "@nestjs/cli": "^10.4.9",
+        "@nestjs/schematics": "^10.0.0",
+        "@types/node": "^20.0.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.0.0"
+    }
 }

--- a/apps/citadel/src/app.controller.ts
+++ b/apps/citadel/src/app.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get } from '@nestjs/common';
-import type { AppService } from './app.service.js';
+import { Controller, Get } from "@nestjs/common";
+import type { AppService } from "./app.service.js";
 
 @Controller()
 export class AppController {
@@ -10,11 +10,11 @@ export class AppController {
         return this.appService.getHello();
     }
 
-    @Get('health')
+    @Get("health")
     healthCheck() {
         return {
-            status: 'ok',
-            service: 'citadel',
+            status: "ok",
+            service: "citadel",
             timestamp: new Date().toISOString(),
         };
     }

--- a/apps/citadel/src/app.module.ts
+++ b/apps/citadel/src/app.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
-import { AppController } from './app.controller.js';
-import { AppService } from './app.service.js';
+import { Module } from "@nestjs/common";
+import { AppController } from "./app.controller.js";
+import { AppService } from "./app.service.js";
 
 @Module({
     imports: [],

--- a/apps/citadel/src/app.service.ts
+++ b/apps/citadel/src/app.service.ts
@@ -1,8 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable } from "@nestjs/common";
 
 @Injectable()
 export class AppService {
     getHello(): string {
-        return '🏰 Welcome to Citadel - Telegram Account Management Service';
+        return "🏰 Welcome to Citadel - Telegram Account Management Service";
     }
 }

--- a/apps/citadel/src/main.ts
+++ b/apps/citadel/src/main.ts
@@ -1,19 +1,16 @@
-import { NestFactory } from '@nestjs/core';
-import type {
-    NestFastifyApplication} from '@nestjs/platform-fastify';
-import {
-    FastifyAdapter
-} from '@nestjs/platform-fastify';
-import { AppModule } from './app.module.js';
+import { NestFactory } from "@nestjs/core";
+import type { NestFastifyApplication } from "@nestjs/platform-fastify";
+import { FastifyAdapter } from "@nestjs/platform-fastify";
+import { AppModule } from "./app.module.js";
 
 async function bootstrap() {
     const app = await NestFactory.create<NestFastifyApplication>(
         AppModule,
-        new FastifyAdapter(),
+        new FastifyAdapter()
     );
 
     const port = Number(process.env.PORT) || 3001;
-    const host = '0.0.0.0';
+    const host = "0.0.0.0";
 
     await app.listen({ port, host });
 

--- a/apps/citadel/tsconfig.json
+++ b/apps/citadel/tsconfig.json
@@ -1,22 +1,22 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "baseUrl": "./",
-    "incremental": true,
-    "skipLibCheck": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "strictBindCallApply": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "noEmit": false
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "test"]
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "baseUrl": "./",
+        "incremental": true,
+        "skipLibCheck": true,
+        "strictNullChecks": true,
+        "noImplicitAny": true,
+        "strictBindCallApply": true,
+        "forceConsistentCasingInFileNames": true,
+        "noFallthroughCasesInSwitch": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
+        "noEmit": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "test"]
 }

--- a/package.json
+++ b/package.json
@@ -1,24 +1,28 @@
 {
-  "name": "forge",
-  "version": "0.0.0",
-  "private": true,
-  "description": "TypeScript monorepo",
-  "scripts": {
-    "dev": "pnpm -r --parallel dev",
-    "dev:citadel": "pnpm --filter @forge/citadel dev",
-    "build": "pnpm -r build",
-    "typecheck": "pnpm -r typecheck",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "clean": "pnpm -r clean && rm -rf node_modules"
-  },
-  "devDependencies": {
-    "@types/node": "^25.3.0",
-    "@typescript-eslint/eslint-plugin": "^8.56.0",
-    "@typescript-eslint/parser": "^8.56.0",
-    "eslint": "^8.57.1",
-    "eslint-import-resolver-typescript": "^4.4.4",
-    "eslint-plugin-import": "^2.32.0",
-    "typescript": "^5.9.3"
-  }
+    "name": "forge",
+    "version": "0.0.0",
+    "private": true,
+    "description": "TypeScript monorepo",
+    "scripts": {
+        "dev": "pnpm -r --parallel dev",
+        "dev:citadel": "pnpm --filter @forge/citadel dev",
+        "build": "pnpm -r build",
+        "typecheck": "pnpm -r typecheck",
+        "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
+        "format": "prettier --write .",
+        "format:check": "prettier --check .",
+        "clean": "pnpm -r clean && rm -rf node_modules"
+    },
+    "devDependencies": {
+        "@types/node": "^25.3.0",
+        "@typescript-eslint/eslint-plugin": "^8.56.0",
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.1",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import": "^2.32.0",
+        "prettier": "^3.8.1",
+        "typescript": "^5.9.3"
+    }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@forge/shared",
-  "version": "0.0.0",
-  "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
-  "scripts": {
-    "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
-  }
+    "name": "@forge/shared",
+    "version": "0.0.0",
+    "private": true,
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "scripts": {
+        "typecheck": "tsc --noEmit",
+        "clean": "rm -rf dist"
+    }
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src/**/*"]
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,18 @@ importers:
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@8.57.1)
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -947,6 +953,12 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
   eslint-import-context@0.1.9:
     resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -1776,6 +1788,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   process-warning@3.0.0:
     resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
@@ -3352,6 +3369,10 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-config-prettier@10.1.8(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
       get-tsconfig: 4.13.6
@@ -4279,6 +4300,8 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.1: {}
 
   process-warning@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
-  - 'apps/*'
-  - 'packages/*'
+    - "apps/*"
+    - "packages/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,23 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "lib": ["ES2022"],
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "allowJs": true,
-    "checkJs": false,
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "incremental": true,
-    "isolatedModules": true,
-    "baseUrl": ".",
-    "paths": {
-      "@forge/*": ["./packages/*/src"]
-    }
-  },
-  "exclude": ["node_modules", "dist", "build"]
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "lib": ["ES2022"],
+        "moduleResolution": "bundler",
+        "resolveJsonModule": true,
+        "allowJs": true,
+        "checkJs": false,
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": true,
+        "incremental": true,
+        "isolatedModules": true,
+        "baseUrl": ".",
+        "paths": {
+            "@forge/*": ["./packages/*/src"]
+        }
+    },
+    "exclude": ["node_modules", "dist", "build"]
 }


### PR DESCRIPTION
- Add Prettier with project formatting rules
- Configure double quotes, 3 spaces, semicolons
- Create .prettierignore for build outputs and .github
- Integrate Prettier with ESLint (eslint-config-prettier)
- Add format and format:check scripts
- Configure VSCode for format on save
- Format entire codebase
closes #13 