### PR TITLE
chore: Make Header data-dumb (content via props)

### DIFF
--- a/apps/ncottage-www/src/app/layout.tsx
+++ b/apps/ncottage-www/src/app/layout.tsx
@@ -2,6 +2,13 @@ import type { Metadata } from "next";
 import { Header } from "@/components/layout/Header";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
+import {
+    ADDRESSES,
+    CITIES,
+    EMAIL,
+    PHONES,
+    WORK_HOURS,
+} from "@/lib/constants";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -18,7 +25,13 @@ export default function RootLayout({
     return (
         <html lang="ru">
             <body>
-                <Header />
+                <Header
+                    cities={CITIES}
+                    phones={PHONES}
+                    addresses={{ spb: ADDRESSES.spb, msk: ADDRESSES.msk }}
+                    email={EMAIL}
+                    workHours={WORK_HOURS}
+                />
                 <Navbar />
                 <main>{children}</main>
                 <Footer />

--- a/apps/ncottage-www/src/components/layout/Header/Header.stories.tsx
+++ b/apps/ncottage-www/src/components/layout/Header/Header.stories.tsx
@@ -1,10 +1,28 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Header } from "./Header";
 
+const defaultArgs = {
+    cities: [
+        { code: "spb" as const, label: "Санкт-Петербург" },
+        { code: "msk" as const, label: "Москва" },
+    ],
+    phones: {
+        spb: { number: "+78123093818", display: "+7 (812) 309-38-18" },
+        msk: { number: "+74952043856", display: "+7 (495) 204-38-56" },
+    },
+    addresses: {
+        spb: "г. Санкт-Петербург, ул. Заставская, д. 31, к. 2, оф. 413",
+        msk: "Варшавское ш. 35 с1, БЦ Ривер Плаза, оф. 412",
+    },
+    email: "info@ncottage.ru",
+    workHours: "Пн–Пт: 10:00–19:00",
+};
+
 const meta: Meta<typeof Header> = {
     title: "Layout/Header",
     component: Header,
     parameters: { layout: "fullscreen" },
+    args: defaultArgs,
 };
 
 export default meta;
@@ -20,4 +38,18 @@ export const Tablet: Story = {
 
 export const Mobile: Story = {
     globals: { viewport: { value: "iphone14", isRotated: false } },
+};
+
+export const OneCity: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+    args: {
+        cities: [{ code: "spb", label: "Санкт-Петербург" }],
+    },
+};
+
+export const MoscowSelected: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+    args: {
+        initialCity: "msk",
+    },
 };

--- a/apps/ncottage-www/src/components/layout/Header/Header.tsx
+++ b/apps/ncottage-www/src/components/layout/Header/Header.tsx
@@ -4,12 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Container } from "@/components/ui/Container";
-import {
-    PHONES,
-    EMAIL,
-    ADDRESSES,
-    WORK_HOURS,
-} from "@/lib/constants";
+import type { City, CityCode, Phone } from "@/lib/constants";
 import {
     ChevronDownIcon,
     ClockIcon,
@@ -19,20 +14,31 @@ import {
 } from "./icons";
 import styles from "./Header.module.css";
 
-type CityCode = "spb" | "msk";
+interface HeaderProps {
+    cities: City[];
+    phones: Record<CityCode, Phone>;
+    addresses: Record<CityCode, string>;
+    email: string;
+    workHours: string;
+    initialCity?: CityCode;
+}
 
-const CITIES: { code: CityCode; label: string }[] = [
-    { code: "spb", label: "Санкт-Петербург" },
-    { code: "msk", label: "Москва" },
-];
-
-export function Header() {
-    const [city, setCity] = useState<CityCode>("spb");
+export function Header({
+    cities,
+    phones,
+    addresses,
+    email,
+    workHours,
+    initialCity,
+}: HeaderProps) {
+    const [city, setCity] = useState<CityCode>(
+        initialCity ?? cities[0].code
+    );
     const [cityOpen, setCityOpen] = useState(false);
 
-    const activePhone = PHONES[city];
-    const address = ADDRESSES[city];
-    const activeCityLabel = CITIES.find((c) => c.code === city)?.label;
+    const activePhone = phones[city];
+    const address = addresses[city];
+    const activeCityLabel = cities.find((c) => c.code === city)?.label;
 
     return (
         <header className={styles.header}>
@@ -60,9 +66,9 @@ export function Header() {
                             <span>{activeCityLabel}</span>
                             <ChevronDownIcon className={styles.cityChevron} />
                         </button>
-                        {cityOpen && (
+                        {cityOpen && cities.length > 1 && (
                             <ul className={styles.cityOptions} role="listbox">
-                                {CITIES.map((c) => (
+                                {cities.map((c) => (
                                     <li
                                         key={c.code}
                                         className={styles.cityOption}
@@ -85,14 +91,14 @@ export function Header() {
                 <div className={styles.contacts}>
                     <span className={styles.contactItem}>
                         <ClockIcon className={styles.contactIcon} />
-                        <span>{WORK_HOURS}</span>
+                        <span>{workHours}</span>
                     </span>
                     <a
-                        href={`mailto:${EMAIL}`}
+                        href={`mailto:${email}`}
                         className={`${styles.contactItem} ${styles.email}`}
                     >
                         <EmailIcon className={styles.contactIcon} />
-                        <span>{EMAIL}</span>
+                        <span>{email}</span>
                     </a>
                 </div>
 
@@ -120,7 +126,7 @@ export function Header() {
                         <PhoneIcon />
                     </a>
                     <a
-                        href={`mailto:${EMAIL}`}
+                        href={`mailto:${email}`}
                         aria-label="Написать"
                         className={styles.mobileIcon}
                     >

--- a/apps/ncottage-www/src/lib/constants.ts
+++ b/apps/ncottage-www/src/lib/constants.ts
@@ -1,6 +1,17 @@
 export const COMPANY_NAME = "Новый Коттедж";
 
-export const PHONES = {
+export type CityCode = "spb" | "msk";
+
+export type City = { code: CityCode; label: string };
+
+export type Phone = { number: string; display: string };
+
+export const CITIES: City[] = [
+    { code: "spb", label: "Санкт-Петербург" },
+    { code: "msk", label: "Москва" },
+];
+
+export const PHONES: Record<CityCode, Phone> = {
     spb: { number: "+78123093818", display: "+7 (812) 309-38-18" },
     msk: { number: "+74952043856", display: "+7 (495) 204-38-56" },
 };


### PR DESCRIPTION
## Summary
- `Header` no longer imports from `@/lib/constants`. Now it accepts `cities`, `phones`, `addresses`, `email`, `workHours` as props, with optional `initialCity` override.
- City selector UI-state (selected city + dropdown open) stays **inside** `Header` — lifting it to a smart container is the next task.
- Types `CityCode`, `City`, `Phone` and constant `CITIES` moved to `src/lib/constants.ts` so props and any future container share a single source of truth.
- `app/layout.tsx` (Server Component) reads constants and feeds them to `<Header />`.
- Storybook gets default `meta.args` plus extra stories: `OneCity` (hides selector via `cities.length > 1` guard), `MoscowSelected` (`initialCity: "msk"`).

Closes #36

## Test plan
- [ ] `pnpm dev:ncottage-www`, verify Header renders identically to before
- [ ] City selector still switches phone + address
- [ ] `pnpm storybook:ncottage-www` — Desktop / Tablet / Mobile / OneCity / MoscowSelected render correctly
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm --filter @forge/ncottage-www build` passes