### PR TITLE
chore: Align story titles with widgets/ directory

### DIFF
--- a/apps/ncottage-www/src/components/widgets/Header/Header.stories.tsx
+++ b/apps/ncottage-www/src/components/widgets/Header/Header.stories.tsx
@@ -22,7 +22,7 @@ const defaultArgs = {
 };
 
 const meta: Meta<typeof Header> = {
-    title: "Layout/Header",
+    title: "Widgets/Header",
     component: Header,
     parameters: { layout: "fullscreen" },
     args: defaultArgs,

--- a/apps/ncottage-www/src/components/widgets/Navbar/Navbar.stories.tsx
+++ b/apps/ncottage-www/src/components/widgets/Navbar/Navbar.stories.tsx
@@ -4,7 +4,7 @@ import { NAV_ITEMS } from "@/lib/constants";
 import { Navbar } from "./Navbar";
 
 const meta: Meta<typeof Navbar> = {
-    title: "Layout/Navbar",
+    title: "Widgets/Navbar",
     component: Navbar,
     parameters: { layout: "fullscreen" },
     args: {

--- a/apps/ncottage-www/src/components/widgets/SiteHeader/SiteHeader.stories.tsx
+++ b/apps/ncottage-www/src/components/widgets/SiteHeader/SiteHeader.stories.tsx
@@ -19,7 +19,7 @@ const defaultArgs = {
 };
 
 const meta: Meta<typeof SiteHeader> = {
-    title: "Layout/SiteHeader",
+    title: "Widgets/SiteHeader",
     component: SiteHeader,
     parameters: { layout: "fullscreen" },
     args: defaultArgs,


### PR DESCRIPTION
Closes #45.

## Summary
- `Header`, `Navbar`, `SiteHeader` переехали в `components/widgets/`, а Storybook-тайтлы остались `Layout/*`. Переименовал в `Widgets/*`, чтобы навигация в Storybook соответствовала структуре директорий.

## Test plan
- [ ] Открыть Storybook, проверить что Header/Navbar/SiteHeader теперь в разделе `Widgets`