### PR TITLE
feat: Transfer project picker widget from ncottage.ru

### DIFF
--- a/apps/ncottage-www/.storybook/preview.ts
+++ b/apps/ncottage-www/.storybook/preview.ts
@@ -15,6 +15,7 @@ const preview: Preview = {
         },
         layout: "centered",
         viewport: { options: INITIAL_VIEWPORTS },
+        nextjs: { appDirectory: true },
     },
 };
 

--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { HeroSection } from "@/components/sections/HeroSection";
+import { ProjectPicker } from "@/components/sections/ProjectPicker";
 import { CategoriesSection } from "@/components/sections/CategoriesSection";
 import { AdvantagesSection } from "@/components/sections/AdvantagesSection";
 import { PopularProjects } from "@/components/sections/PopularProjects";
@@ -8,7 +9,7 @@ import { GallerySection } from "@/components/sections/GallerySection";
 import { ReviewsSection } from "@/components/sections/ReviewsSection";
 import { CtaSection } from "@/components/sections/CtaSection";
 import { ContactForm } from "@/components/sections/ContactForm";
-import { HERO } from "@/lib/constants";
+import { HERO, PROJECT_PICKER } from "@/lib/constants";
 import { getReviews, getGallery } from "@/lib/data";
 
 export default function HomePage() {
@@ -23,6 +24,16 @@ export default function HomePage() {
                 text={HERO.text}
                 cta={HERO.cta}
                 image={HERO.image}
+            />
+            <ProjectPicker
+                title={PROJECT_PICKER.title}
+                text={PROJECT_PICKER.text}
+                price={PROJECT_PICKER.price}
+                area={PROJECT_PICKER.area}
+                technologies={PROJECT_PICKER.technologies}
+                floors={PROJECT_PICKER.floors}
+                submitLabel={PROJECT_PICKER.submitLabel}
+                overlap
             />
             <CategoriesSection />
             <AdvantagesSection />

--- a/apps/ncottage-www/src/components/sections/ProjectPicker/ProjectPicker.module.css
+++ b/apps/ncottage-www/src/components/sections/ProjectPicker/ProjectPicker.module.css
@@ -1,0 +1,251 @@
+.widget {
+    position: relative;
+    z-index: 2;
+    padding: 0 15px;
+}
+
+.widgetOverlap {
+    margin-top: -80px;
+}
+
+.wrapper {
+    max-width: 1230px;
+    width: 100%;
+    margin: 0 auto;
+    background: #fff;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    border-radius: 5px;
+    padding: 33px 28px;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    column-gap: 32px;
+    row-gap: 28px;
+}
+
+.wrapper > * {
+    min-width: 0;
+}
+
+.heading {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    grid-column: span 1;
+}
+
+.title {
+    font-family: "Montserrat", sans-serif;
+    font-weight: 900;
+    font-size: 26px;
+    line-height: 1.2;
+    text-transform: uppercase;
+    color: var(--color-text);
+    margin-bottom: 7px;
+}
+
+.text {
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 24px;
+    color: var(--color-text);
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+}
+
+.fieldTitle {
+    font-weight: 700;
+    font-size: 18px;
+    line-height: 28px;
+    color: var(--color-text);
+    margin-bottom: 10px;
+}
+
+.rangeInputs {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.numberInput {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 12px;
+    font-family: "Montserrat", sans-serif;
+    font-weight: 400;
+    font-size: 15px;
+    line-height: 24px;
+    color: var(--color-text-dark);
+    border: 1px solid var(--color-border-light);
+    border-radius: 2px;
+    box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.08);
+    background: #fff;
+}
+
+.numberInput:focus {
+    border-color: var(--color-green);
+}
+
+.slider {
+    position: relative;
+    height: 24px;
+}
+
+.sliderTrack,
+.sliderRange {
+    position: absolute;
+    top: 50%;
+    height: 7px;
+    border-radius: 2px;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.sliderTrack {
+    left: 0;
+    right: 0;
+    background: var(--color-border);
+    border: 1px solid var(--color-border-light);
+}
+
+.sliderRange {
+    background: var(--color-green);
+}
+
+.sliderInput {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 24px;
+    transform: translateY(-50%);
+    background: none;
+    appearance: none;
+    pointer-events: none;
+}
+
+.sliderInput::-webkit-slider-thumb {
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 2px;
+    background: var(--color-green);
+    border: 1px solid var(--color-green);
+    cursor: pointer;
+    pointer-events: auto;
+}
+
+.sliderInput::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+    border-radius: 2px;
+    background: var(--color-green);
+    border: 1px solid var(--color-green);
+    cursor: pointer;
+    pointer-events: auto;
+}
+
+.sliderInput::-webkit-slider-runnable-track,
+.sliderInput::-moz-range-track {
+    background: transparent;
+    border: none;
+}
+
+.select {
+    width: 100%;
+    height: 43px;
+    padding: 5px 15px;
+    font-family: "Montserrat", sans-serif;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 33px;
+    color: var(--color-text);
+    background: #fff;
+    border-radius: 2px;
+    box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+    appearance: auto;
+}
+
+.submitCell {
+    display: flex;
+    align-items: flex-end;
+}
+
+.submit {
+    width: 100%;
+    min-width: 0;
+    min-height: 43px;
+    padding: 8px 12px;
+    font-family: "Montserrat", sans-serif;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 1.4;
+    color: var(--color-text-white);
+    background: var(--color-green);
+    border-radius: 5px;
+    box-shadow: 0 2px 1px var(--color-green);
+    transition: background-color var(--transition);
+}
+
+.submit:hover {
+    background: var(--color-green-hover);
+}
+
+.submit:active {
+    background: var(--color-green-dark);
+}
+
+@media (max-width: 989px) {
+    .wrapper {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        column-gap: 24px;
+        row-gap: 24px;
+        padding: 28px 22px;
+    }
+
+    .heading {
+        grid-column: span 2;
+    }
+
+    .submitCell {
+        grid-column: span 2;
+    }
+
+    .title {
+        font-size: 22px;
+    }
+}
+
+@media (max-width: 560px) {
+    .widget {
+        padding: 0 10px;
+    }
+
+    .widgetOverlap {
+        margin-top: -40px;
+    }
+
+    .wrapper {
+        grid-template-columns: 1fr;
+        padding: 22px 18px;
+        row-gap: 20px;
+    }
+
+    .heading,
+    .submitCell {
+        grid-column: auto;
+    }
+
+    .title {
+        font-size: 20px;
+    }
+
+    .text {
+        font-size: 15px;
+        line-height: 22px;
+    }
+}

--- a/apps/ncottage-www/src/components/sections/ProjectPicker/ProjectPicker.stories.tsx
+++ b/apps/ncottage-www/src/components/sections/ProjectPicker/ProjectPicker.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PROJECT_PICKER } from "@/lib/constants";
+import { ProjectPicker } from "./ProjectPicker";
+
+const meta: Meta<typeof ProjectPicker> = {
+    title: "Sections/ProjectPicker",
+    component: ProjectPicker,
+    parameters: { layout: "fullscreen" },
+    args: {
+        title: PROJECT_PICKER.title,
+        text: PROJECT_PICKER.text,
+        price: PROJECT_PICKER.price,
+        area: PROJECT_PICKER.area,
+        technologies: PROJECT_PICKER.technologies,
+        floors: PROJECT_PICKER.floors,
+        submitLabel: PROJECT_PICKER.submitLabel,
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProjectPicker>;
+
+export const Desktop: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+};
+
+export const Tablet: Story = {
+    globals: { viewport: { value: "ipad", isRotated: false } },
+};
+
+export const Mobile: Story = {
+    globals: { viewport: { value: "iphone14", isRotated: false } },
+};
+
+export const OverlapHero: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+    args: { overlap: true },
+    decorators: [
+        (Story) => (
+            <div>
+                <div
+                    style={{
+                        height: 420,
+                        background:
+                            "linear-gradient(135deg, #2c2c2c, #479332)",
+                    }}
+                />
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/apps/ncottage-www/src/components/sections/ProjectPicker/ProjectPicker.tsx
+++ b/apps/ncottage-www/src/components/sections/ProjectPicker/ProjectPicker.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { ProjectPickerContent } from "@/lib/constants";
+import styles from "./ProjectPicker.module.css";
+
+interface ProjectPickerProps {
+    title: ProjectPickerContent["title"];
+    text: ProjectPickerContent["text"];
+    price: ProjectPickerContent["price"];
+    area: ProjectPickerContent["area"];
+    technologies: ProjectPickerContent["technologies"];
+    floors: ProjectPickerContent["floors"];
+    submitLabel: ProjectPickerContent["submitLabel"];
+    overlap?: boolean;
+}
+
+const numberFormat = new Intl.NumberFormat("ru-RU");
+
+function formatPrice(value: number) {
+    return numberFormat.format(value);
+}
+
+function formatArea(value: number) {
+    return `${numberFormat.format(value)} м²`;
+}
+
+function parseDigits(raw: string) {
+    const digits = raw.replace(/\D/g, "");
+    return digits === "" ? null : Number(digits);
+}
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+}
+
+export function ProjectPicker({
+    title,
+    text,
+    price,
+    area,
+    technologies,
+    floors,
+    submitLabel,
+    overlap = false,
+}: ProjectPickerProps) {
+    const router = useRouter();
+    const [priceMin, setPriceMin] = useState(price.min);
+    const [priceMax, setPriceMax] = useState(price.max);
+    const [areaMin, setAreaMin] = useState(area.min);
+    const [areaMax, setAreaMax] = useState(area.max);
+    const [priceMinDraft, setPriceMinDraft] = useState(formatPrice(price.min));
+    const [priceMaxDraft, setPriceMaxDraft] = useState(formatPrice(price.max));
+    const [areaMinDraft, setAreaMinDraft] = useState(formatArea(area.min));
+    const [areaMaxDraft, setAreaMaxDraft] = useState(formatArea(area.max));
+    const [tech, setTech] = useState("");
+    const [floor, setFloor] = useState("");
+
+    const pricePercentMin =
+        ((priceMin - price.min) / (price.max - price.min)) * 100;
+    const pricePercentMax =
+        ((priceMax - price.min) / (price.max - price.min)) * 100;
+    const areaPercentMin = ((areaMin - area.min) / (area.max - area.min)) * 100;
+    const areaPercentMax = ((areaMax - area.min) / (area.max - area.min)) * 100;
+
+    function commitPriceMin() {
+        const parsed = parseDigits(priceMinDraft);
+        const next =
+            parsed === null ? priceMin : clamp(parsed, price.min, priceMax);
+        setPriceMin(next);
+        setPriceMinDraft(formatPrice(next));
+    }
+
+    function commitPriceMax() {
+        const parsed = parseDigits(priceMaxDraft);
+        const next =
+            parsed === null ? priceMax : clamp(parsed, priceMin, price.max);
+        setPriceMax(next);
+        setPriceMaxDraft(formatPrice(next));
+    }
+
+    function commitAreaMin() {
+        const parsed = parseDigits(areaMinDraft);
+        const next =
+            parsed === null ? areaMin : clamp(parsed, area.min, areaMax);
+        setAreaMin(next);
+        setAreaMinDraft(formatArea(next));
+    }
+
+    function commitAreaMax() {
+        const parsed = parseDigits(areaMaxDraft);
+        const next =
+            parsed === null ? areaMax : clamp(parsed, areaMin, area.max);
+        setAreaMax(next);
+        setAreaMaxDraft(formatArea(next));
+    }
+
+    function syncPriceMin(value: number) {
+        setPriceMin(value);
+        setPriceMinDraft(formatPrice(value));
+    }
+
+    function syncPriceMax(value: number) {
+        setPriceMax(value);
+        setPriceMaxDraft(formatPrice(value));
+    }
+
+    function syncAreaMin(value: number) {
+        setAreaMin(value);
+        setAreaMinDraft(formatArea(value));
+    }
+
+    function syncAreaMax(value: number) {
+        setAreaMax(value);
+        setAreaMaxDraft(formatArea(value));
+    }
+
+    function handleSubmit() {
+        const params = new URLSearchParams();
+        if (priceMin !== price.min) params.set("priceMin", String(priceMin));
+        if (priceMax !== price.max) params.set("priceMax", String(priceMax));
+        if (areaMin !== area.min) params.set("areaMin", String(areaMin));
+        if (areaMax !== area.max) params.set("areaMax", String(areaMax));
+        if (tech) params.set("tech", tech);
+        if (floor) params.set("floors", floor);
+        const query = params.toString();
+        router.push(query ? `/projects?${query}` : "/projects");
+    }
+
+    return (
+        <section
+            className={
+                overlap
+                    ? `${styles.widget} ${styles.widgetOverlap}`
+                    : styles.widget
+            }
+        >
+            <div className={styles.wrapper}>
+                <div className={styles.heading}>
+                    <h2 className={styles.title}>{title}</h2>
+                    <p className={styles.text}>{text}</p>
+                </div>
+
+                <div className={styles.field}>
+                    <h3 className={styles.fieldTitle}>Цена (руб.)</h3>
+                    <div className={styles.rangeInputs}>
+                        <input
+                            className={styles.numberInput}
+                            type="text"
+                            inputMode="numeric"
+                            value={priceMinDraft}
+                            aria-label="Цена от"
+                            onChange={(e) => setPriceMinDraft(e.target.value)}
+                            onBlur={commitPriceMin}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") e.currentTarget.blur();
+                            }}
+                        />
+                        <input
+                            className={styles.numberInput}
+                            type="text"
+                            inputMode="numeric"
+                            value={priceMaxDraft}
+                            aria-label="Цена до"
+                            onChange={(e) => setPriceMaxDraft(e.target.value)}
+                            onBlur={commitPriceMax}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") e.currentTarget.blur();
+                            }}
+                        />
+                    </div>
+                    <div className={styles.slider}>
+                        <div className={styles.sliderTrack} />
+                        <div
+                            className={styles.sliderRange}
+                            style={{
+                                left: `${pricePercentMin}%`,
+                                right: `${100 - pricePercentMax}%`,
+                            }}
+                        />
+                        <input
+                            className={styles.sliderInput}
+                            type="range"
+                            min={price.min}
+                            max={price.max}
+                            value={priceMin}
+                            aria-label="Минимальная цена"
+                            onChange={(e) =>
+                                syncPriceMin(
+                                    Math.min(Number(e.target.value), priceMax)
+                                )
+                            }
+                        />
+                        <input
+                            className={styles.sliderInput}
+                            type="range"
+                            min={price.min}
+                            max={price.max}
+                            value={priceMax}
+                            aria-label="Максимальная цена"
+                            onChange={(e) =>
+                                syncPriceMax(
+                                    Math.max(Number(e.target.value), priceMin)
+                                )
+                            }
+                        />
+                    </div>
+                </div>
+
+                <div className={styles.field}>
+                    <h3 className={styles.fieldTitle}>Площадь</h3>
+                    <div className={styles.rangeInputs}>
+                        <input
+                            className={styles.numberInput}
+                            type="text"
+                            inputMode="numeric"
+                            value={areaMinDraft}
+                            aria-label="Площадь от"
+                            onChange={(e) => setAreaMinDraft(e.target.value)}
+                            onBlur={commitAreaMin}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") e.currentTarget.blur();
+                            }}
+                        />
+                        <input
+                            className={styles.numberInput}
+                            type="text"
+                            inputMode="numeric"
+                            value={areaMaxDraft}
+                            aria-label="Площадь до"
+                            onChange={(e) => setAreaMaxDraft(e.target.value)}
+                            onBlur={commitAreaMax}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") e.currentTarget.blur();
+                            }}
+                        />
+                    </div>
+                    <div className={styles.slider}>
+                        <div className={styles.sliderTrack} />
+                        <div
+                            className={styles.sliderRange}
+                            style={{
+                                left: `${areaPercentMin}%`,
+                                right: `${100 - areaPercentMax}%`,
+                            }}
+                        />
+                        <input
+                            className={styles.sliderInput}
+                            type="range"
+                            min={area.min}
+                            max={area.max}
+                            value={areaMin}
+                            aria-label="Минимальная площадь"
+                            onChange={(e) =>
+                                syncAreaMin(
+                                    Math.min(Number(e.target.value), areaMax)
+                                )
+                            }
+                        />
+                        <input
+                            className={styles.sliderInput}
+                            type="range"
+                            min={area.min}
+                            max={area.max}
+                            value={areaMax}
+                            aria-label="Максимальная площадь"
+                            onChange={(e) =>
+                                syncAreaMax(
+                                    Math.max(Number(e.target.value), areaMin)
+                                )
+                            }
+                        />
+                    </div>
+                </div>
+
+                <div className={styles.field}>
+                    <h3 className={styles.fieldTitle}>Технология</h3>
+                    <select
+                        className={styles.select}
+                        value={tech}
+                        onChange={(e) => setTech(e.target.value)}
+                        aria-label="Технология"
+                    >
+                        {technologies.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className={styles.field}>
+                    <h3 className={styles.fieldTitle}>Количество этажей</h3>
+                    <select
+                        className={styles.select}
+                        value={floor}
+                        onChange={(e) => setFloor(e.target.value)}
+                        aria-label="Количество этажей"
+                    >
+                        {floors.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className={styles.submitCell}>
+                    <button
+                        type="button"
+                        className={styles.submit}
+                        onClick={handleSubmit}
+                    >
+                        {submitLabel}
+                    </button>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/apps/ncottage-www/src/components/sections/ProjectPicker/index.ts
+++ b/apps/ncottage-www/src/components/sections/ProjectPicker/index.ts
@@ -1,0 +1,1 @@
+export { ProjectPicker } from "./ProjectPicker";

--- a/apps/ncottage-www/src/lib/constants.ts
+++ b/apps/ncottage-www/src/lib/constants.ts
@@ -217,6 +217,41 @@ export const HERO: HeroContent = {
     image: { src: "/images/hero/banner.jpg", alt: "" },
 };
 
+export type RangeBounds = { min: number; max: number };
+
+export type SelectOption = { value: string; label: string };
+
+export type ProjectPickerContent = {
+    title: string;
+    text: string;
+    price: RangeBounds;
+    area: RangeBounds;
+    technologies: SelectOption[];
+    floors: SelectOption[];
+    submitLabel: string;
+};
+
+export const PROJECT_PICKER: ProjectPickerContent = {
+    title: "Подберите проект",
+    text: "Из более 50 готовых проектов на нашем сайте",
+    price: { min: 3_160_780, max: 36_946_370 },
+    area: { min: 67, max: 679 },
+    technologies: [
+        { value: "", label: "Не имеет значения" },
+        { value: "sip", label: "Дом из SIP-панелей" },
+        { value: "aerocrete", label: "Дом из газобетона" },
+        { value: "brick", label: "Дом из кирпича" },
+        { value: "frame", label: "Каркасный дом" },
+        { value: "fachwerk", label: "Фахверковые дома" },
+    ],
+    floors: [
+        { value: "", label: "Не имеет значения" },
+        { value: "1", label: "1" },
+        { value: "2", label: "2" },
+    ],
+    submitLabel: "Подобрать подходящий проект",
+};
+
 export const NAV_ITEMS: NavItem[] = [
     {
         label: "Проекты",


### PR DESCRIPTION
Closes #46.

## Summary
- Новая секция `sections/ProjectPicker/` — overlay-карточка `front-page__widget` с ncottage.ru: два dual-range слайдера (цена, площадь), два select-а (технология, этажность), CTA-кнопка.
- Data-dumb: принимает контент пропсами, дефолты в `PROJECT_PICKER` (`lib/constants.ts`). Опциональный `overlap` prop включает отрицательный margin, чтобы карточка наезжала на Hero — передаём только из `page.tsx`, в Storybook по дефолту выключено.
- Инпуты цены/площади: draft-state, clamp на blur/Enter (а не во время ввода) — чтобы юзер мог свободно редактировать.
- Submit → `router.push("/projects?…")` с выбранными параметрами (сам фильтр на `/projects` — вне скоупа).
- `.storybook/preview.ts`: `nextjs: { appDirectory: true }` — моки `useRouter` из `next/navigation` для всех историй.

## Test plan
- [ ] `pnpm dev:ncottage-www` → главная: карточка наезжает на Hero, фильтры работают
- [ ] Ввод в инпутах цены/площади не сбрасывает значения во время печати; blur/Enter кламплет в границы
- [ ] Слайдеры синхронизируют инпуты и наоборот
- [ ] Клик по "Подобрать подходящий проект" → `/projects?priceMin=…&priceMax=…&…`
- [ ] Storybook `Sections/ProjectPicker`: Desktop/Tablet/Mobile/OverlapHero рендерятся без ошибок, контент не выезжает за карточку
- [ ] `pnpm typecheck`, `pnpm --filter @forge/ncottage-www build` проходят