### PR TITLE
refactor: Align CategoriesSection with ncottage.ru parity

### DIFF
--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -9,10 +9,11 @@ import { GallerySection } from "@/components/sections/GallerySection";
 import { ReviewsSection } from "@/components/sections/ReviewsSection";
 import { CtaSection } from "@/components/sections/CtaSection";
 import { ContactForm } from "@/components/sections/ContactForm";
-import { HERO, PROJECT_PICKER } from "@/lib/constants";
-import { getReviews, getGallery } from "@/lib/data";
+import { CATEGORIES_SECTION, HERO, PROJECT_PICKER } from "@/lib/constants";
+import { getCategories, getReviews, getGallery } from "@/lib/data";
 
 export default function HomePage() {
+    const categories = getCategories();
     const reviews = getReviews();
     const gallery = getGallery();
 
@@ -35,7 +36,11 @@ export default function HomePage() {
                 submitLabel={PROJECT_PICKER.submitLabel}
                 overlap
             />
-            <CategoriesSection />
+            <CategoriesSection
+                title={CATEGORIES_SECTION.title}
+                categories={categories}
+                cta={CATEGORIES_SECTION.cta}
+            />
             <AdvantagesSection />
             <PopularProjects />
             <CalculatorWizard />

--- a/apps/ncottage-www/src/components/sections/CategoriesSection/CategoriesSection.module.css
+++ b/apps/ncottage-www/src/components/sections/CategoriesSection/CategoriesSection.module.css
@@ -38,15 +38,45 @@
 
 .badge {
     position: absolute;
-    top: 15px;
-    left: 15px;
+    top: 20px;
+    right: 20px;
     padding: 5px 15px;
-    font-size: 12px;
+    font-size: 16px;
     font-weight: 500;
+    line-height: 24px;
     color: var(--color-text-dark);
     background-color: #fff;
-    border-radius: 3px;
+    border-radius: 5px;
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.15);
+    transition:
+        background-color var(--transition),
+        color var(--transition);
     z-index: 1;
+}
+
+.card:hover .badge {
+    background-color: var(--color-green);
+    color: #fff;
+}
+
+.arrow {
+    position: absolute;
+    right: 20px;
+    bottom: 20px;
+    padding: 12px;
+    border: 1px solid #fff;
+    border-radius: 5px;
+    opacity: 0;
+    transform: translateY(4px);
+    transition:
+        opacity var(--transition),
+        transform var(--transition);
+    z-index: 1;
+}
+
+.card:hover .arrow {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .cardBottom {

--- a/apps/ncottage-www/src/components/sections/CategoriesSection/CategoriesSection.stories.tsx
+++ b/apps/ncottage-www/src/components/sections/CategoriesSection/CategoriesSection.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CATEGORIES_SECTION } from "@/lib/constants";
+import { getCategories } from "@/lib/data";
+import { CategoriesSection } from "./CategoriesSection";
+
+const categories = getCategories();
+
+const meta: Meta<typeof CategoriesSection> = {
+    title: "Sections/CategoriesSection",
+    component: CategoriesSection,
+    parameters: { layout: "fullscreen" },
+    args: {
+        title: CATEGORIES_SECTION.title,
+        categories,
+        cta: CATEGORIES_SECTION.cta,
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof CategoriesSection>;
+
+export const Desktop: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+};
+
+export const Tablet: Story = {
+    globals: { viewport: { value: "ipad", isRotated: false } },
+};
+
+export const Mobile: Story = {
+    globals: { viewport: { value: "iphone14", isRotated: false } },
+};
+
+export const FewCategories: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+    args: {
+        categories: categories.slice(0, 2),
+    },
+};

--- a/apps/ncottage-www/src/components/sections/CategoriesSection/CategoriesSection.tsx
+++ b/apps/ncottage-www/src/components/sections/CategoriesSection/CategoriesSection.tsx
@@ -1,54 +1,95 @@
+"use client";
+
 import Link from "next/link";
+import { useState } from "react";
 import { Container } from "@/components/ui/Container";
-import { getCategories } from "@/lib/data";
+import { CallbackModal } from "@/components/shared/CallbackModal";
+import type { CategoriesSectionContent } from "@/lib/constants";
+import type { Category } from "@/types/common";
 import styles from "./CategoriesSection.module.css";
 
-export function CategoriesSection() {
-    const categories = getCategories();
+interface CategoriesSectionProps {
+    title: CategoriesSectionContent["title"];
+    categories: Category[];
+    cta: CategoriesSectionContent["cta"];
+}
+
+function ArrowIcon() {
+    return (
+        <svg
+            width="19"
+            height="14"
+            viewBox="0 0 19 14"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+        >
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M18.03 6.46997C18.1705 6.6106 18.2493 6.80122 18.2493 6.99997C18.2493 7.19872 18.1705 7.38934 18.03 7.52997L12.03 13.53C11.8887 13.6665 11.6994 13.742 11.5029 13.7403C11.3064 13.7386 11.1184 13.6598 10.9795 13.5208C10.8406 13.3819 10.7617 13.1939 10.76 12.9974C10.7583 12.8009 10.8338 12.6116 10.9703 12.4703L15.6903 7.74997H1.49997C1.30106 7.74997 1.11029 7.67095 0.969638 7.5303C0.828986 7.38965 0.749969 7.19888 0.749969 6.99997C0.749969 6.80106 0.828986 6.61029 0.969638 6.46964C1.11029 6.32899 1.30106 6.24997 1.49997 6.24997H15.6903L10.9703 1.52997C10.8338 1.38869 10.7583 1.19937 10.76 1.00287C10.7617 0.806368 10.8406 0.61838 10.9795 0.479457C11.1184 0.340535 11.3064 0.261643 11.5029 0.259959C11.6994 0.258274 11.8887 0.333932 12.03 0.47047L18.03 6.47047V6.46997Z"
+                fill="white"
+            />
+        </svg>
+    );
+}
+
+export function CategoriesSection({
+    title,
+    categories,
+    cta,
+}: CategoriesSectionProps) {
+    const [modalOpen, setModalOpen] = useState(false);
 
     return (
         <section className={styles.section}>
             <Container>
-                <h2 className={styles.title}>
-                    Строительство домов в СПб и ЛО
-                </h2>
+                <h2 className={styles.title}>{title}</h2>
                 <div className={styles.grid}>
-                    {categories.map((cat) => (
+                    {categories.map((category) => (
                         <Link
-                            key={cat.slug}
-                            href={`/projects?tech=${cat.technology}`}
+                            key={category.slug}
+                            href={`/projects?tech=${category.technology}`}
                             className={styles.card}
                         >
                             <img
-                                src={cat.image}
-                                alt={cat.title}
+                                src={category.image}
+                                alt={category.title}
                                 className={styles.cardImage}
                             />
                             <span className={styles.badge}>
-                                {cat.count} проектов
+                                {category.count}&nbsp;проектов
                             </span>
                             <div className={styles.cardBottom}>
                                 <h3 className={styles.cardTitle}>
-                                    {cat.title}
+                                    {category.title}
                                 </h3>
+                            </div>
+                            <div
+                                className={styles.arrow}
+                                aria-hidden="true"
+                            >
+                                <ArrowIcon />
                             </div>
                         </Link>
                     ))}
-                    {/* CTA block */}
                     <div className={styles.ctaBlock}>
-                        <h3 className={styles.ctaTitle}>
-                            Не знаете, что выбрать?
-                        </h3>
-                        <p className={styles.ctaText}>
-                            Оставьте заявку и наши специалисты свяжутся с
-                            вами в самое ближайшее время!
-                        </p>
-                        <button className={styles.ctaBtn}>
-                            Бесплатная консультация
+                        <h3 className={styles.ctaTitle}>{cta.title}</h3>
+                        <p className={styles.ctaText}>{cta.text}</p>
+                        <button
+                            type="button"
+                            className={styles.ctaBtn}
+                            onClick={() => setModalOpen(true)}
+                        >
+                            {cta.ctaLabel}
                         </button>
                     </div>
                 </div>
             </Container>
+            <CallbackModal
+                open={modalOpen}
+                onClose={() => setModalOpen(false)}
+            />
         </section>
     );
 }

--- a/apps/ncottage-www/src/lib/constants.ts
+++ b/apps/ncottage-www/src/lib/constants.ts
@@ -231,6 +231,24 @@ export type ProjectPickerContent = {
     submitLabel: string;
 };
 
+export type CategoriesSectionContent = {
+    title: string;
+    cta: {
+        title: string;
+        text: string;
+        ctaLabel: string;
+    };
+};
+
+export const CATEGORIES_SECTION: CategoriesSectionContent = {
+    title: "Строительство домов в СПб и ЛО",
+    cta: {
+        title: "Не знаете, что выбрать?",
+        text: "Оставьте заявку и наши специалисты свяжутся с вами в самое ближайшее время!",
+        ctaLabel: "Бесплатная консультация",
+    },
+};
+
 export const PROJECT_PICKER: ProjectPickerContent = {
     title: "Подберите проект",
     text: "Из более 50 готовых проектов на нашем сайте",


### PR DESCRIPTION
## Summary
- `CategoriesSection` становится data-dumb: принимает `title`, `categories`, `cta` пропсами; `getCategories()` вызывается в `page.tsx`
- Добавлена arrow-иконка справа-снизу каждой карточки + hover-эффекты (scale изображения, зелёный badge, fade-in стрелки)
- CTA-кнопка «Бесплатная консультация» открывает `CallbackModal` через локальный state
- Дефолтный контент (заголовок секции + CTA) вынесен в `lib/constants.ts` как `CATEGORIES_SECTION`
- Добавлены Storybook-истории: desktop / tablet / mobile + вариант с 2 категориями

Closes #48

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm --filter @forge/ncottage-www build`
- [ ] `pnpm storybook:ncottage-www` — проверить все 4 story на desktop/tablet/mobile
- [ ] Визуальное сравнение с ncottage.ru на desktop / tablet / mobile
- [ ] Клик по CTA-кнопке открывает `CallbackModal`