### PR TITLE
chore: Ignore *.code-workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Thumbs.db
 *.swo
 *~
 .sublime-*
+*.code-workspace
 
 # Logs
 logs/


### PR DESCRIPTION
Closes #52.

## Summary
- Добавлен паттерн `*.code-workspace` в секцию IDE в `.gitignore`, чтобы VS Code multi-root workspace-файлы не попадали в репу.

## Test plan
- [x] Локальный `forge.code-workspace` больше не показывается в `git status`.