### PR TITLE
refactor: QuizSection UX polish and unknown option

### DIFF
--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -52,7 +52,6 @@ export default function HomePage() {
                 title={QUIZ_SECTION.title}
                 speaker={QUIZ_SECTION.speaker}
                 steps={QUIZ_SECTION.steps}
-                consultationLabel={QUIZ_SECTION.consultationLabel}
                 prevLabel={QUIZ_SECTION.prevLabel}
                 nextLabel={QUIZ_SECTION.nextLabel}
                 submitLabel={QUIZ_SECTION.submitLabel}

--- a/apps/ncottage-www/src/components/sections/QuizSection/QuizSection.module.css
+++ b/apps/ncottage-www/src/components/sections/QuizSection/QuizSection.module.css
@@ -3,6 +3,15 @@
     background-color: #f8f8f8;
 }
 
+.preload {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+    pointer-events: none;
+    opacity: 0;
+}
+
 .title {
     font-size: 26px;
     font-weight: 700;
@@ -21,20 +30,8 @@
     box-shadow: 0 5px 20px rgba(0, 0, 0, 0.05);
 }
 
-.progress {
-    margin-bottom: 25px;
-    font-size: 13px;
-    color: var(--color-text);
-}
-
-.progressLabel,
-.progressSteps,
-.progressSep {
-    display: inline;
-}
-
 .progressBarWrap {
-    margin-top: 8px;
+    margin-bottom: 25px;
     height: 6px;
     background-color: #e2e2e2;
     border-radius: 3px;
@@ -121,6 +118,19 @@
     object-fit: cover;
 }
 
+.imageChoiceImagePlaceholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    background-color: #eef4ea;
+    color: var(--color-green);
+    font-size: 48px;
+    font-weight: 700;
+    line-height: 1;
+}
+
 .imageChoiceText {
     display: block;
     padding: 10px 12px;
@@ -143,32 +153,6 @@
     border: 0;
 }
 
-/* Consultation checkbox */
-
-.consultation {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 14px;
-    border: 1px solid var(--color-border);
-    border-radius: 4px;
-    font-size: 13px;
-    color: var(--color-text);
-    cursor: pointer;
-    transition: border-color var(--transition);
-}
-
-.consultation:hover {
-    border-color: var(--color-green);
-}
-
-.consultation input[type="checkbox"] {
-    accent-color: var(--color-green);
-    width: 16px;
-    height: 16px;
-    margin: 0;
-}
-
 /* Range slider */
 
 .range {
@@ -186,7 +170,6 @@
     background-size: 50% 100%;
     outline: none;
     margin: 25px 0 15px;
-    transition: background-size 0.1s linear;
 }
 
 .range::-webkit-slider-thumb {
@@ -337,10 +320,16 @@
     margin-left: auto;
 }
 
-.navNext:hover,
-.navSubmit:hover {
+.navNext:hover:not(:disabled),
+.navSubmit:hover:not(:disabled) {
     background-color: var(--color-green-hover);
     border-color: var(--color-green-hover);
+}
+
+.navNext:disabled,
+.navSubmit:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 /* Sidebar */
@@ -412,14 +401,27 @@
 .stepCounter {
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 2px;
-    font-size: 13px;
-    color: var(--color-text);
     text-align: center;
 }
 
-.stepCounterText {
-    display: block;
+.stepCounterNumber {
+    font-size: 48px;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-green);
+}
+
+.stepCounterLabel {
+    font-size: 13px;
+    color: var(--color-text);
+}
+
+.stepCounterFinal {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--color-text-dark);
 }
 
 /* Success */
@@ -472,8 +474,13 @@
 
     .stepCounter {
         flex-direction: row;
-        gap: 6px;
+        align-items: center;
+        gap: 8px;
         margin-left: auto;
+    }
+
+    .stepCounterNumber {
+        font-size: 32px;
     }
 }
 

--- a/apps/ncottage-www/src/components/sections/QuizSection/QuizSection.stories.tsx
+++ b/apps/ncottage-www/src/components/sections/QuizSection/QuizSection.stories.tsx
@@ -11,7 +11,6 @@ const meta: Meta<typeof QuizSection> = {
         title: QUIZ_SECTION.title,
         speaker: QUIZ_SECTION.speaker,
         steps: QUIZ_SECTION.steps,
-        consultationLabel: QUIZ_SECTION.consultationLabel,
         prevLabel: QUIZ_SECTION.prevLabel,
         nextLabel: QUIZ_SECTION.nextLabel,
         submitLabel: QUIZ_SECTION.submitLabel,

--- a/apps/ncottage-www/src/components/sections/QuizSection/QuizSection.tsx
+++ b/apps/ncottage-www/src/components/sections/QuizSection/QuizSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducer } from "react";
+import { useMemo, useReducer } from "react";
 import { Container } from "@/components/ui/Container";
 import type { QuizSectionContent, QuizStep } from "@/lib/constants";
 import styles from "./QuizSection.module.css";
@@ -9,7 +9,6 @@ export type QuizAnswer = string | number | null;
 
 export type QuizData = {
     values: Record<string, QuizAnswer>;
-    consultation: Record<string, boolean>;
     name: string;
     phone: string;
 };
@@ -18,7 +17,6 @@ interface QuizSectionProps {
     title: QuizSectionContent["title"];
     speaker: QuizSectionContent["speaker"];
     steps: QuizSectionContent["steps"];
-    consultationLabel: QuizSectionContent["consultationLabel"];
     prevLabel: QuizSectionContent["prevLabel"];
     nextLabel: QuizSectionContent["nextLabel"];
     submitLabel: QuizSectionContent["submitLabel"];
@@ -31,7 +29,6 @@ interface QuizSectionProps {
 interface QuizState {
     step: number;
     values: Record<string, QuizAnswer>;
-    consultation: Record<string, boolean>;
     name: string;
     phone: string;
     submitted: boolean;
@@ -39,7 +36,6 @@ interface QuizState {
 
 type QuizAction =
     | { type: "SET_VALUE"; fieldId: string; value: QuizAnswer }
-    | { type: "TOGGLE_CONSULTATION"; fieldId: string }
     | { type: "SET_NAME"; value: string }
     | { type: "SET_PHONE"; value: string }
     | { type: "NEXT"; max: number }
@@ -58,11 +54,24 @@ function createInitialState(steps: QuizStep[]): QuizState {
     return {
         step: 0,
         values,
-        consultation: {},
         name: "",
         phone: "",
         submitted: false,
     };
+}
+
+function isStepComplete(step: QuizStep, state: QuizState): boolean {
+    switch (step.kind) {
+        case "image-choice":
+        case "text-radio": {
+            const value = state.values[step.fieldId];
+            return typeof value === "string" && value.length > 0;
+        }
+        case "range":
+            return true;
+        case "contact":
+            return state.name.trim() !== "" && state.phone.trim() !== "";
+    }
 }
 
 function reducer(state: QuizState, action: QuizAction): QuizState {
@@ -71,14 +80,6 @@ function reducer(state: QuizState, action: QuizAction): QuizState {
             return {
                 ...state,
                 values: { ...state.values, [action.fieldId]: action.value },
-            };
-        case "TOGGLE_CONSULTATION":
-            return {
-                ...state,
-                consultation: {
-                    ...state.consultation,
-                    [action.fieldId]: !state.consultation[action.fieldId],
-                },
             };
         case "SET_NAME":
             return { ...state, name: action.value };
@@ -93,15 +94,10 @@ function reducer(state: QuizState, action: QuizAction): QuizState {
     }
 }
 
-function formatPercent(current: number, total: number) {
-    return `${Math.round((current / total) * 100)}%`;
-}
-
 export function QuizSection({
     title,
     speaker,
     steps,
-    consultationLabel,
     prevLabel,
     nextLabel,
     submitLabel,
@@ -116,11 +112,23 @@ export function QuizSection({
     const questionCount = steps.filter((s) => s.kind !== "contact").length;
     const currentStep = steps[state.step];
     const isLast = state.step === totalSteps - 1;
+    const canAdvance = isStepComplete(currentStep, state);
+
+    const preloadImages = useMemo(() => {
+        const urls: string[] = [];
+        for (const s of steps) {
+            if (s.kind === "image-choice") {
+                for (const option of s.options) {
+                    if (option.image) urls.push(option.image);
+                }
+            }
+        }
+        return urls;
+    }, [steps]);
 
     function handleSubmit() {
         onSubmit?.({
             values: state.values,
-            consultation: state.consultation,
             name: state.name,
             phone: state.phone,
         });
@@ -151,16 +159,28 @@ export function QuizSection({
                                         <label
                                             className={styles.imageChoiceLabel}
                                         >
-                                            <span
-                                                className={
-                                                    styles.imageChoiceImage
-                                                }
-                                            >
-                                                <img
-                                                    src={option.image}
-                                                    alt={option.label}
-                                                />
-                                            </span>
+                                            {option.image ? (
+                                                <span
+                                                    className={
+                                                        styles.imageChoiceImage
+                                                    }
+                                                >
+                                                    <img
+                                                        src={option.image}
+                                                        alt={option.label}
+                                                        decoding="sync"
+                                                    />
+                                                </span>
+                                            ) : (
+                                                <span
+                                                    className={
+                                                        styles.imageChoiceImagePlaceholder
+                                                    }
+                                                    aria-hidden="true"
+                                                >
+                                                    ?
+                                                </span>
+                                            )}
                                             <input
                                                 type="radio"
                                                 name={step.fieldId}
@@ -187,23 +207,6 @@ export function QuizSection({
                                 );
                             })}
                         </ul>
-                        {step.showConsultation && (
-                            <label className={styles.consultation}>
-                                <input
-                                    type="checkbox"
-                                    checked={Boolean(
-                                        state.consultation[step.fieldId]
-                                    )}
-                                    onChange={() =>
-                                        dispatch({
-                                            type: "TOGGLE_CONSULTATION",
-                                            fieldId: step.fieldId,
-                                        })
-                                    }
-                                />
-                                <span>{consultationLabel}</span>
-                            </label>
-                        )}
                     </>
                 );
             }
@@ -340,16 +343,16 @@ export function QuizSection({
                 <div className={styles.cloud}>{step.cloud}</div>
                 <div className={styles.stepCounter}>
                     {step.kind === "contact" ? (
-                        <span className={styles.stepCounterText}>
+                        <span className={styles.stepCounterFinal}>
                             {lastStepLabel}
                         </span>
                     ) : (
                         <>
-                            <span className={styles.stepCounterText}>
-                                {stepNumber} шаг
+                            <span className={styles.stepCounterNumber}>
+                                {stepNumber}
                             </span>
-                            <span className={styles.stepCounterText}>
-                                из {questionCount}
+                            <span className={styles.stepCounterLabel}>
+                                шаг из {questionCount}
                             </span>
                         </>
                     )}
@@ -374,25 +377,21 @@ export function QuizSection({
 
     return (
         <section className={styles.section}>
+            <div aria-hidden="true" className={styles.preload}>
+                {preloadImages.map((src) => (
+                    <img key={src} src={src} alt="" />
+                ))}
+            </div>
             <Container>
                 <h2 className={styles.title}>{title}</h2>
                 <div className={styles.quiz}>
-                    <div className={styles.progress}>
-                        <span className={styles.progressLabel}>
-                            {formatPercent(state.step, totalSteps - 1)}
-                        </span>
-                        <span className={styles.progressSep}> - </span>
-                        <span className={styles.progressSteps}>
-                            Step {state.step + 1} of {totalSteps}
-                        </span>
-                        <div className={styles.progressBarWrap}>
-                            <div
-                                className={styles.progressBar}
-                                style={{
-                                    width: `${((state.step + 1) / totalSteps) * 100}%`,
-                                }}
-                            />
-                        </div>
+                    <div className={styles.progressBarWrap}>
+                        <div
+                            className={styles.progressBar}
+                            style={{
+                                width: `${((state.step + 1) / totalSteps) * 100}%`,
+                            }}
+                        />
                     </div>
                     <div className={styles.layout}>
                         <div className={styles.main}>
@@ -414,6 +413,7 @@ export function QuizSection({
                                         type="button"
                                         className={`${styles.navButton} ${styles.navSubmit}`}
                                         onClick={handleSubmit}
+                                        disabled={!canAdvance}
                                     >
                                         {submitLabel}
                                     </button>
@@ -427,6 +427,7 @@ export function QuizSection({
                                                 max: totalSteps - 1,
                                             })
                                         }
+                                        disabled={!canAdvance}
                                     >
                                         {nextLabel}
                                     </button>

--- a/apps/ncottage-www/src/lib/constants.ts
+++ b/apps/ncottage-www/src/lib/constants.ts
@@ -258,7 +258,7 @@ export type QuizSpeaker = {
 export type QuizImageOption = {
     value: string;
     label: string;
-    image: string;
+    image?: string;
 };
 
 export type QuizTextOption = {
@@ -273,7 +273,6 @@ export type QuizStep =
           label: string;
           cloud: string;
           options: QuizImageOption[];
-          showConsultation?: boolean;
       }
     | {
           kind: "range";
@@ -307,7 +306,6 @@ export type QuizStep =
 export type QuizSectionContent = {
     title: string;
     speaker: QuizSpeaker;
-    consultationLabel: string;
     prevLabel: string;
     nextLabel: string;
     submitLabel: string;
@@ -324,7 +322,6 @@ export const QUIZ_SECTION: QuizSectionContent = {
         role: "специалист по строительству",
         avatar: "/images/quiz/anton.webp",
     },
-    consultationLabel: "Не знаю, нужна консультация",
     prevLabel: "Назад",
     nextLabel: "Далее",
     submitLabel: "Получить расчёт",
@@ -338,7 +335,6 @@ export const QUIZ_SECTION: QuizSectionContent = {
             fieldId: "floors",
             label: "Этаж дома",
             cloud: "Расскажите, сколько этажей будет в вашем доме? Выберите один из вариантов ответа.",
-            showConsultation: true,
             options: [
                 {
                     value: "1 этаж",
@@ -354,6 +350,10 @@ export const QUIZ_SECTION: QuizSectionContent = {
                     value: "2 этажа",
                     label: "2 этажа",
                     image: "/images/quiz/2floor.jpg",
+                },
+                {
+                    value: "unknown",
+                    label: "Не знаю, нужна консультация",
                 },
             ],
         },
@@ -373,7 +373,6 @@ export const QUIZ_SECTION: QuizSectionContent = {
             fieldId: "foundation",
             label: "Фундамент дома",
             cloud: "Супер! Осталось всего 3 шага, чтобы узнать предварительную смету под ваш бюджет.",
-            showConsultation: true,
             options: [
                 {
                     value: "Сваи",
@@ -405,6 +404,10 @@ export const QUIZ_SECTION: QuizSectionContent = {
                     label: "Комбинированный фундамент",
                     image: "/images/quiz/foundation-combined.jpg",
                 },
+                {
+                    value: "unknown",
+                    label: "Не знаю, нужна консультация",
+                },
             ],
         },
         {
@@ -412,7 +415,6 @@ export const QUIZ_SECTION: QuizSectionContent = {
             fieldId: "roof",
             label: "Тип кровли",
             cloud: "Осталось совсем немножко. Давай теперь выберем тип кровли.",
-            showConsultation: true,
             options: [
                 {
                     value: "Металлочерепица",
@@ -443,6 +445,10 @@ export const QUIZ_SECTION: QuizSectionContent = {
                     value: "Мембранная кровля",
                     label: "Мембранная кровля",
                     image: "/images/quiz/roof-membrane.jpg",
+                },
+                {
+                    value: "unknown",
+                    label: "Не знаю, нужна консультация",
                 },
             ],
         },


### PR DESCRIPTION
Closes #54. Closes #55.

## Summary
- `QuizSection`: «Не знаю, нужна консультация» стал обычным вариантом в сетке image-choice (`value: "unknown"`), карточка с placeholder-иконкой «?» вместо фото. Убраны `showConsultation`, `consultationLabel`, параллельное состояние `consultation: Record<string, boolean>` в `QuizData`. Сигнал «нужна консультация» теперь через `values[fieldId] === "unknown"`.
- `QuizImageOption.image` стал опциональным (вариант-заглушка рисует «?» вместо картинки).
- Слайдер (шаг 2): убран `transition: background-size 0.1s linear` — заливка ехала за thumb со смазыванием при дискретном `step=10`.
- Top progress: убрана английская строка `"17% - Step 2 of 7"` — дублировала sidebar counter и сбивала денумераторами (7 всех шагов vs 6 вопросов). Оставлен только сам progress bar.
- Sidebar step counter: current step теперь крупной зелёной цифрой, мелко «шаг из N» под ней; на контактном шаге — «Заключительный шаг» выделенным стилем.
- Прелоад всех картинок квиза через скрытый `<div>` с `<img>` при монтировании секции + `decoding="sync"` на видимых img — уменьшает мерцание при переходах между шагами.
- Кнопки «Далее» / «Получить расчёт» disabled если на текущем шаге нет валидного ответа (`image-choice`/`text-radio` — не выбран вариант, `contact` — пустые name/phone, `range` — всегда ok).

## Test plan
- [x] `pnpm --filter @forge/ncottage-www typecheck`
- [x] `pnpm lint`
- [x] `pnpm exec prettier --check` на изменённых файлах
- [ ] `pnpm storybook:ncottage-www` — пройти все 7 шагов на Desktop / Tablet / Mobile:
  - Шаги 1/3/4: «Не знаю, нужна консультация» — последняя карточка в сетке с плейсхолдером «?». Чекбокса под сеткой нет. Выделяется по клику как остальные.
  - Шаг 2: слайдер тянется без смазывания заливки.
  - Верх: только progress bar, без английского текста.
  - Sidebar: большая зелёная цифра текущего шага, на контактном — «Заключительный шаг».
  - Без выбора варианта кнопка «Далее» / «Получить расчёт» задизейблена (opacity 0.5, cursor not-allowed).
  - На Tablet/Mobile step counter перестраивается в строку (цифра 32px + текст рядом).