### PR TITLE
refactor: QuizSection placement and desktop sizing on home page

### DIFF
--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -46,8 +46,6 @@ export default function HomePage() {
                 categories={categories}
                 cta={CATEGORIES_SECTION.cta}
             />
-            <AdvantagesSection />
-            <PopularProjects />
             <QuizSection
                 title={QUIZ_SECTION.title}
                 speaker={QUIZ_SECTION.speaker}
@@ -59,6 +57,8 @@ export default function HomePage() {
                 successTitle={QUIZ_SECTION.successTitle}
                 successText={QUIZ_SECTION.successText}
             />
+            <AdvantagesSection />
+            <PopularProjects />
             <StagesSection />
             <GallerySection items={gallery} />
             <ReviewsSection reviews={reviews} />

--- a/apps/ncottage-www/src/components/sections/QuizSection/QuizSection.module.css
+++ b/apps/ncottage-www/src/components/sections/QuizSection/QuizSection.module.css
@@ -13,18 +13,18 @@
 }
 
 .title {
-    font-size: 26px;
+    font-size: 30px;
     font-weight: 700;
-    line-height: 32px;
+    line-height: 38px;
     color: var(--color-text-dark);
     text-align: center;
-    margin-bottom: 35px;
+    margin-bottom: 40px;
 }
 
 .quiz {
-    max-width: 960px;
+    max-width: 1140px;
     margin: 0 auto;
-    padding: 30px;
+    padding: 40px;
     background-color: #fff;
     border-radius: 5px;
     box-shadow: 0 5px 20px rgba(0, 0, 0, 0.05);
@@ -58,10 +58,10 @@
 
 .fieldLabel {
     display: block;
-    font-size: 16px;
+    font-size: 18px;
     font-weight: 600;
     color: var(--color-text-dark);
-    margin-bottom: 18px;
+    margin-bottom: 22px;
 }
 
 .required {
@@ -126,15 +126,15 @@
     aspect-ratio: 4 / 3;
     background-color: #eef4ea;
     color: var(--color-green);
-    font-size: 48px;
+    font-size: 56px;
     font-weight: 700;
     line-height: 1;
 }
 
 .imageChoiceText {
     display: block;
-    padding: 10px 12px;
-    font-size: 13px;
+    padding: 12px 14px;
+    font-size: 15px;
     font-weight: 500;
     color: var(--color-text-dark);
     text-align: center;
@@ -195,12 +195,12 @@
 }
 
 .rangeHint {
-    font-size: 16px;
+    font-size: 18px;
     color: var(--color-text-dark);
 }
 
 .rangeHint b {
-    font-size: 24px;
+    font-size: 28px;
     font-weight: 700;
     color: var(--color-green);
 }
@@ -220,10 +220,10 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 12px 16px;
+    padding: 14px 18px;
     border: 1px solid var(--color-border);
     border-radius: 4px;
-    font-size: 14px;
+    font-size: 16px;
     color: var(--color-text-dark);
     cursor: pointer;
     transition:
@@ -248,10 +248,10 @@
 /* Contact */
 
 .contactHeading {
-    font-size: 18px;
+    font-size: 20px;
     font-weight: 600;
     color: var(--color-text-dark);
-    margin-bottom: 18px;
+    margin-bottom: 22px;
 }
 
 .contactInputs {
@@ -261,8 +261,8 @@
 }
 
 .input {
-    padding: 14px 16px;
-    font-size: 14px;
+    padding: 16px 18px;
+    font-size: 16px;
     color: var(--color-text-dark);
     background-color: #fff;
     border: 1px solid var(--color-border);
@@ -290,8 +290,8 @@
 }
 
 .navButton {
-    padding: 12px 28px;
-    font-size: 14px;
+    padding: 14px 32px;
+    font-size: 16px;
     font-weight: 500;
     border-radius: 4px;
     cursor: pointer;
@@ -378,10 +378,10 @@
 
 .cloud {
     position: relative;
-    padding: 15px 18px;
+    padding: 16px 20px;
     background-color: var(--color-green);
     color: #fff;
-    font-size: 14px;
+    font-size: 16px;
     line-height: 1.4;
     border-radius: 8px;
 }
@@ -407,14 +407,14 @@
 }
 
 .stepCounterNumber {
-    font-size: 48px;
+    font-size: 56px;
     font-weight: 700;
     line-height: 1;
     color: var(--color-green);
 }
 
 .stepCounterLabel {
-    font-size: 13px;
+    font-size: 14px;
     color: var(--color-text);
 }
 


### PR DESCRIPTION
Closes #57.

## Summary
- `page.tsx`: переместил `<QuizSection>` на 4-ю позицию — между `<CategoriesSection>` и `<AdvantagesSection>`. Парити по позиции конверсионного элемента: квиз попадается юзеру до большого каталога проектов, а не после.
- `QuizSection.module.css`: подтянул размеры на десктопе к остальным секциям главной.
  - Карточка `.quiz`: max-width 960 → 1140px (под `--container-width: 1170px`), padding 30 → 40px.
  - `.title`: 26 → 30px (как Advantages/Popular/Stages), line-height 32 → 38, margin-bottom 35 → 40.
  - Body-текст +1-3px по всем элементам интерфейса квиза: `.fieldLabel` 16→18, `.imageChoiceText` 13→15, `.cloud` 14→16, `.textRadioLabel` 14→16, `.contactHeading` 18→20, `.input` 14→16, `.navButton` 14→16, `.rangeHint` 16→18 (b 24→28), `.stepCounterNumber` 48→56, `.stepCounterLabel` 13→14, placeholder «?» 48→56.
- Mobile/tablet breakpoints (900/600/400) не трогал: существующие override'ы уже сжимают title, padding и сетку.

Итоговый порядок секций: Hero → ProjectPicker → CategoriesSection → QuizSection → AdvantagesSection → PopularProjects → StagesSection → GallerySection → ReviewsSection → CtaSection → ContactForm.

## Test plan
- [x] `pnpm --filter @forge/ncottage-www typecheck`
- [x] `pnpm exec prettier --check` на изменённых файлах
- [ ] `pnpm dev:ncottage-www` — главная: проскроллить, убедиться что квиз идёт после CategoriesSection и перед AdvantagesSection, ничего не разъехалось.
- [ ] Visual desktop ≥ 1170px: карточка квиза по ширине совпадает с соседними секциями, title и body-текст не выглядят мельче.
- [ ] Visual tablet ~768px и mobile ~375px: квиз не разваливается, sidebar переходит в строку, image grid — 2/1 колонки.