### PR TITLE
feat: ViewRequestSection (front-page__green-row parity)

### DIFF
--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -66,8 +66,6 @@ export default function HomePage() {
                 background={ADVANTAGES_SECTION.background}
                 items={ADVANTAGES_SECTION.items}
             />
-            <PopularProjects />
-            <StagesSection />
             <ViewRequestSection
                 title={VIEW_REQUEST_SECTION.title}
                 nameLabel={VIEW_REQUEST_SECTION.nameLabel}
@@ -79,6 +77,8 @@ export default function HomePage() {
                 successTitle={VIEW_REQUEST_SECTION.successTitle}
                 successText={VIEW_REQUEST_SECTION.successText}
             />
+            <PopularProjects />
+            <StagesSection />
             <GallerySection items={gallery} />
             <ReviewsSection reviews={reviews} />
             <CtaSection />

--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -9,12 +9,14 @@ import { GallerySection } from "@/components/sections/GallerySection";
 import { ReviewsSection } from "@/components/sections/ReviewsSection";
 import { CtaSection } from "@/components/sections/CtaSection";
 import { ContactForm } from "@/components/sections/ContactForm";
+import { ViewRequestSection } from "@/components/sections/ViewRequestSection";
 import {
     ADVANTAGES_SECTION,
     CATEGORIES_SECTION,
     HERO,
     PROJECT_PICKER,
     QUIZ_SECTION,
+    VIEW_REQUEST_SECTION,
 } from "@/lib/constants";
 import { getCategories, getReviews, getGallery } from "@/lib/data";
 
@@ -66,6 +68,17 @@ export default function HomePage() {
             />
             <PopularProjects />
             <StagesSection />
+            <ViewRequestSection
+                title={VIEW_REQUEST_SECTION.title}
+                nameLabel={VIEW_REQUEST_SECTION.nameLabel}
+                namePlaceholder={VIEW_REQUEST_SECTION.namePlaceholder}
+                phoneLabel={VIEW_REQUEST_SECTION.phoneLabel}
+                phonePlaceholder={VIEW_REQUEST_SECTION.phonePlaceholder}
+                submitLabel={VIEW_REQUEST_SECTION.submitLabel}
+                privacy={VIEW_REQUEST_SECTION.privacy}
+                successTitle={VIEW_REQUEST_SECTION.successTitle}
+                successText={VIEW_REQUEST_SECTION.successText}
+            />
             <GallerySection items={gallery} />
             <ReviewsSection reviews={reviews} />
             <CtaSection />

--- a/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.module.css
+++ b/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.module.css
@@ -32,16 +32,14 @@
 }
 
 .fields {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 15px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    align-items: start;
+    gap: 30px;
 }
 
 .field {
-    flex: 1 1 380px;
-    max-width: 380px;
+    width: 100%;
 }
 
 .srOnly {
@@ -82,10 +80,9 @@
 }
 
 .submit {
-    flex: 1 1 380px;
-    max-width: 380px;
+    width: 100%;
     height: 43px;
-    background: #e84836;
+    background: var(--color-red);
     border: none;
     border-radius: 5px;
     outline: none;
@@ -100,17 +97,12 @@
     transition: background-color var(--transition);
 }
 
-.submit:hover:not(:disabled) {
+.submit:hover {
     background: #fa5341;
 }
 
-.submit:active:not(:disabled) {
+.submit:active {
     background: #d64332;
-}
-
-.submit:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
 }
 
 .privacy {
@@ -160,18 +152,7 @@
     }
 
     .fields {
-        flex-direction: column;
-        gap: 0;
-    }
-
-    .field,
-    .submit {
-        flex: 1 1 auto;
-        max-width: 100%;
-        width: 100%;
-    }
-
-    .field {
-        margin-bottom: 20px;
+        grid-template-columns: 1fr;
+        gap: 20px;
     }
 }

--- a/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.module.css
+++ b/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.module.css
@@ -1,0 +1,177 @@
+.section {
+    width: 100%;
+    min-height: 220px;
+    padding: 53px 0 59px;
+    background: linear-gradient(
+        270deg,
+        rgba(71, 147, 50, 0.95) 0%,
+        rgba(71, 147, 50, 0.95) 53.09%,
+        rgba(71, 147, 50, 0.95) 100.93%
+    );
+}
+
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.title {
+    width: 100%;
+    margin-bottom: 31px;
+    font-weight: 900;
+    font-size: 26px;
+    line-height: 32px;
+    text-align: center;
+    text-transform: uppercase;
+    color: #fff;
+}
+
+.form {
+    width: 100%;
+}
+
+.fields {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 15px;
+}
+
+.field {
+    flex: 1 1 380px;
+    max-width: 380px;
+}
+
+.srOnly {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.input {
+    width: 100%;
+    height: 43px;
+    padding-left: 23px;
+    background: #fff;
+    border: 1px solid #b7b7b7;
+    border-radius: 5px;
+    outline: none;
+    appearance: none;
+    font-family: inherit;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 19.5px;
+    color: var(--color-text);
+}
+
+.input::placeholder {
+    color: var(--color-text);
+    opacity: 1;
+}
+
+.input:focus {
+    border-color: var(--color-bg-green);
+}
+
+.submit {
+    flex: 1 1 380px;
+    max-width: 380px;
+    height: 43px;
+    background: #e84836;
+    border: none;
+    border-radius: 5px;
+    outline: none;
+    appearance: none;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 20px;
+    text-transform: uppercase;
+    color: #fff;
+    transition: background-color var(--transition);
+}
+
+.submit:hover:not(:disabled) {
+    background: #fa5341;
+}
+
+.submit:active:not(:disabled) {
+    background: #d64332;
+}
+
+.submit:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.privacy {
+    width: 100%;
+    margin-top: 15px;
+    font-size: 13px;
+    line-height: 20px;
+    color: #fff;
+}
+
+.privacyLink {
+    color: #fff;
+    text-decoration: underline;
+}
+
+.privacyLink:hover {
+    text-decoration: none;
+}
+
+.success {
+    width: 100%;
+    color: #fff;
+    text-align: center;
+}
+
+.successTitle {
+    margin-bottom: 8px;
+    font-weight: 700;
+    font-size: 22px;
+    line-height: 28px;
+    text-transform: uppercase;
+}
+
+.successText {
+    font-size: 16px;
+    line-height: 24px;
+}
+
+@media (max-width: 768px) {
+    .section {
+        padding: 38px 0 50px;
+    }
+
+    .title {
+        font-size: 22px;
+        line-height: 26px;
+    }
+
+    .fields {
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .field,
+    .submit {
+        flex: 1 1 auto;
+        max-width: 100%;
+        width: 100%;
+    }
+
+    .field {
+        margin-bottom: 20px;
+    }
+}

--- a/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.stories.tsx
+++ b/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { VIEW_REQUEST_SECTION } from "@/lib/constants";
+import { ViewRequestSection } from "./ViewRequestSection";
+
+const meta: Meta<typeof ViewRequestSection> = {
+    title: "Sections/ViewRequestSection",
+    component: ViewRequestSection,
+    parameters: { layout: "fullscreen" },
+    args: {
+        title: VIEW_REQUEST_SECTION.title,
+        nameLabel: VIEW_REQUEST_SECTION.nameLabel,
+        namePlaceholder: VIEW_REQUEST_SECTION.namePlaceholder,
+        phoneLabel: VIEW_REQUEST_SECTION.phoneLabel,
+        phonePlaceholder: VIEW_REQUEST_SECTION.phonePlaceholder,
+        submitLabel: VIEW_REQUEST_SECTION.submitLabel,
+        privacy: VIEW_REQUEST_SECTION.privacy,
+        successTitle: VIEW_REQUEST_SECTION.successTitle,
+        successText: VIEW_REQUEST_SECTION.successText,
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof ViewRequestSection>;
+
+export const Desktop: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+};
+
+export const Tablet: Story = {
+    globals: { viewport: { value: "ipad", isRotated: false } },
+};
+
+export const Mobile: Story = {
+    globals: { viewport: { value: "iphone14", isRotated: false } },
+};

--- a/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.tsx
+++ b/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { Container } from "@/components/ui/Container";
+import type { ViewRequestSectionContent } from "@/lib/constants";
+import styles from "./ViewRequestSection.module.css";
+
+interface ViewRequestSectionProps {
+    title: ViewRequestSectionContent["title"];
+    nameLabel: ViewRequestSectionContent["nameLabel"];
+    namePlaceholder: ViewRequestSectionContent["namePlaceholder"];
+    phoneLabel: ViewRequestSectionContent["phoneLabel"];
+    phonePlaceholder: ViewRequestSectionContent["phonePlaceholder"];
+    submitLabel: ViewRequestSectionContent["submitLabel"];
+    privacy: ViewRequestSectionContent["privacy"];
+    successTitle: ViewRequestSectionContent["successTitle"];
+    successText: ViewRequestSectionContent["successText"];
+}
+
+export function ViewRequestSection({
+    title,
+    nameLabel,
+    namePlaceholder,
+    phoneLabel,
+    phonePlaceholder,
+    submitLabel,
+    privacy,
+    successTitle,
+    successText,
+}: ViewRequestSectionProps) {
+    const [name, setName] = useState("");
+    const [phone, setPhone] = useState("");
+    const [submitted, setSubmitted] = useState(false);
+
+    function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!phone.trim()) return;
+        console.log("ViewRequestSection submit:", { name, phone });
+        setSubmitted(true);
+    }
+
+    return (
+        <section className={styles.section}>
+            <Container className={styles.wrapper}>
+                <h2 className={styles.title}>{title}</h2>
+                {submitted ? (
+                    <div className={styles.success} role="status">
+                        <p className={styles.successTitle}>{successTitle}</p>
+                        <p className={styles.successText}>{successText}</p>
+                    </div>
+                ) : (
+                    <form className={styles.form} onSubmit={handleSubmit}>
+                        <div className={styles.fields}>
+                            <label className={styles.field}>
+                                <span className={styles.srOnly}>
+                                    {nameLabel}
+                                </span>
+                                <input
+                                    className={styles.input}
+                                    type="text"
+                                    name="name"
+                                    autoComplete="name"
+                                    placeholder={namePlaceholder}
+                                    value={name}
+                                    onChange={(event) =>
+                                        setName(event.target.value)
+                                    }
+                                />
+                            </label>
+                            <label className={styles.field}>
+                                <span className={styles.srOnly}>
+                                    {phoneLabel}
+                                </span>
+                                <input
+                                    className={styles.input}
+                                    type="tel"
+                                    name="phone"
+                                    autoComplete="tel"
+                                    placeholder={phonePlaceholder}
+                                    value={phone}
+                                    onChange={(event) =>
+                                        setPhone(event.target.value)
+                                    }
+                                    required
+                                />
+                            </label>
+                            <button
+                                type="submit"
+                                className={styles.submit}
+                                disabled={!phone.trim()}
+                            >
+                                {submitLabel}
+                            </button>
+                        </div>
+                        <p className={styles.privacy}>
+                            {privacy.text}{" "}
+                            <a
+                                className={styles.privacyLink}
+                                href={privacy.linkHref}
+                            >
+                                {privacy.linkLabel}
+                            </a>
+                        </p>
+                    </form>
+                )}
+            </Container>
+        </section>
+    );
+}

--- a/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.tsx
+++ b/apps/ncottage-www/src/components/sections/ViewRequestSection/ViewRequestSection.tsx
@@ -84,11 +84,7 @@ export function ViewRequestSection({
                                     required
                                 />
                             </label>
-                            <button
-                                type="submit"
-                                className={styles.submit}
-                                disabled={!phone.trim()}
-                            >
+                            <button type="submit" className={styles.submit}>
                                 {submitLabel}
                             </button>
                         </div>

--- a/apps/ncottage-www/src/components/sections/ViewRequestSection/index.ts
+++ b/apps/ncottage-www/src/components/sections/ViewRequestSection/index.ts
@@ -1,0 +1,1 @@
+export { ViewRequestSection } from "./ViewRequestSection";

--- a/apps/ncottage-www/src/lib/constants.ts
+++ b/apps/ncottage-www/src/lib/constants.ts
@@ -300,6 +300,38 @@ export const ADVANTAGES_SECTION: AdvantagesSectionContent = {
     ],
 };
 
+export type ViewRequestSectionContent = {
+    title: string;
+    nameLabel: string;
+    namePlaceholder: string;
+    phoneLabel: string;
+    phonePlaceholder: string;
+    submitLabel: string;
+    privacy: {
+        text: string;
+        linkLabel: string;
+        linkHref: string;
+    };
+    successTitle: string;
+    successText: string;
+};
+
+export const VIEW_REQUEST_SECTION: ViewRequestSectionContent = {
+    title: "Оставить заявку на просмотр построенных домов",
+    nameLabel: "Ваше имя",
+    namePlaceholder: "Ваше имя",
+    phoneLabel: "Телефон",
+    phonePlaceholder: "Телефон *",
+    submitLabel: "Отправить",
+    privacy: {
+        text: "Нажимая на кнопку «Отправить», вы даёте согласие на обработку своих персональных данных. Ознакомиться с",
+        linkLabel: "политикой конфиденциальности.",
+        linkHref: "/privacy",
+    },
+    successTitle: "Заявка отправлена",
+    successText: "Мы свяжемся с вами в течение 15 минут.",
+};
+
 export type QuizSpeaker = {
     name: string;
     role: string;


### PR DESCRIPTION
Closes #61.

## Summary
- Новый компонент `ViewRequestSection` (зелёная CTA-полоса с заявкой на просмотр построенных домов): заголовок + три инпута в строку (имя, телефон, кнопка) + текст согласия на ОПД, по референсу `front-page__green-row` ncottage.ru.
- Контент в `VIEW_REQUEST_SECTION` (`@/lib/constants`), компонент принимает все строки и privacy-блок пропсами.
- Стили: зелёный фон `rgba(71,147,50,.95)`, заголовок Montserrat 900 26/32 uppercase, поля 380px max-width, кнопка `#E84836` → hover `#FA5341` / active `#D64332`.
- Mobile (≤768px): поля и кнопка в колонку, заголовок 22/26.
- Сабмит — клиентский (как `ContactForm`): `console.log` + success-блок, без бэка. Кнопка отключена пока телефон пустой.
- Подключён в `app/page.tsx` между `StagesSection` и `GallerySection`.
- Storybook story `Sections/ViewRequestSection` (Desktop / Tablet / Mobile).

## Test plan
- [ ] `pnpm --filter @forge/ncottage-www typecheck`
- [ ] Главная: секция между «Этапы строительства» и «Галерея», зелёная полоса, поля 380px в строку, текст согласия под формой
- [ ] Сабмит без телефона невозможен (кнопка disabled), с телефоном — показывается success-блок
- [ ] Mobile (≤768px): поля и кнопка в колонку, заголовок 22/26, отступы корректные
- [ ] Storybook: `pnpm storybook:ncottage-www` → `Sections/ViewRequestSection` все вьюпорты