### PR TITLE
feat: OurWorksSection (front-page__works parity)

### DIFF
--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -6,6 +6,7 @@ import { PopularProjects } from "@/components/sections/PopularProjects";
 import { QuizSection } from "@/components/sections/QuizSection";
 import { StagesSection } from "@/components/sections/StagesSection";
 import { GallerySection } from "@/components/sections/GallerySection";
+import { OurWorksSection } from "@/components/sections/OurWorksSection";
 import { ReviewsSection } from "@/components/sections/ReviewsSection";
 import { CtaSection } from "@/components/sections/CtaSection";
 import { ContactForm } from "@/components/sections/ContactForm";
@@ -14,6 +15,7 @@ import {
     ADVANTAGES_SECTION,
     CATEGORIES_SECTION,
     HERO,
+    OUR_WORKS_SECTION,
     POPULAR_PROJECTS_SECTION,
     PROJECT_PICKER,
     QUIZ_SECTION,
@@ -24,6 +26,7 @@ import {
     getReviews,
     getGallery,
     getFeaturedProjects,
+    getBuiltObjects,
 } from "@/lib/data";
 
 export default function HomePage() {
@@ -31,6 +34,7 @@ export default function HomePage() {
     const reviews = getReviews();
     const gallery = getGallery();
     const featuredProjects = getFeaturedProjects();
+    const builtObjects = getBuiltObjects();
 
     return (
         <>
@@ -92,6 +96,12 @@ export default function HomePage() {
                 tabs={POPULAR_PROJECTS_SECTION.tabs}
                 cta={POPULAR_PROJECTS_SECTION.cta}
                 projects={featuredProjects}
+            />
+            <OurWorksSection
+                title={OUR_WORKS_SECTION.title}
+                tabs={OUR_WORKS_SECTION.tabs}
+                cta={OUR_WORKS_SECTION.cta}
+                objects={builtObjects}
             />
             <StagesSection />
             <GallerySection items={gallery} />

--- a/apps/ncottage-www/src/components/sections/OurWorksSection/OurWorksSection.module.css
+++ b/apps/ncottage-www/src/components/sections/OurWorksSection/OurWorksSection.module.css
@@ -1,0 +1,216 @@
+.section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    padding: 42px 0 60px;
+}
+
+.wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    width: 100%;
+    max-width: 1230px;
+    padding: 0 15px;
+    margin: 0 auto;
+}
+
+.title {
+    margin: 0;
+    font-weight: 900;
+    font-size: 26px;
+    line-height: 45px;
+    text-transform: uppercase;
+    color: var(--color-text);
+}
+
+.tabs {
+    display: flex;
+    align-items: center;
+    width: 414px;
+    height: 43px;
+    gap: 10px;
+}
+
+.tab {
+    flex: 1 1 50%;
+    height: 43px;
+    padding: 0 12px;
+    font-family: inherit;
+    font-size: 16px;
+    line-height: 39px;
+    letter-spacing: 0.005em;
+    text-align: center;
+    color: var(--color-text);
+    background: transparent;
+    border: 2px solid var(--color-bg-green);
+    border-radius: 2px;
+    text-decoration: none;
+    cursor: pointer;
+    box-sizing: border-box;
+    transition:
+        color var(--transition),
+        background-color var(--transition);
+}
+
+.tab:hover {
+    color: #fff;
+    background-color: var(--color-bg-green);
+}
+
+.tabActive {
+    color: #fff;
+    background-color: var(--color-bg-green);
+    cursor: default;
+}
+
+.carousel {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: calc((100vw - 60px) / 3);
+    column-gap: 30px;
+    width: 100%;
+    margin-top: 45px;
+    margin-bottom: 38px;
+    padding: 4px max(calc((100vw - 1230px) / 2 + 15px), 15px);
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scroll-snap-type: x mandatory;
+    scroll-padding-left: max(calc((100vw - 1230px) / 2 + 15px), 15px);
+    scrollbar-width: none;
+}
+
+.carousel::-webkit-scrollbar {
+    display: none;
+}
+
+.card {
+    position: relative;
+    display: block;
+    width: 100%;
+    aspect-ratio: 584 / 350;
+    overflow: hidden;
+    border-radius: 5px;
+    color: #fff;
+    text-decoration: none;
+    background-color: var(--color-bg-light);
+    scroll-snap-align: start;
+    isolation: isolate;
+}
+
+.image {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.6s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
+.card:hover .image {
+    transform: scale(1.06);
+}
+
+.card::before {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 40%;
+    z-index: 2;
+    background: linear-gradient(
+        180.45deg,
+        rgba(0, 0, 0, 0) 1%,
+        rgba(0, 0, 0, 0.85) 99.84%
+    );
+    pointer-events: none;
+}
+
+.cardTitle {
+    position: absolute;
+    bottom: 20px;
+    left: 17px;
+    right: 17px;
+    z-index: 4;
+    margin: 0;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 28px;
+    color: #fff;
+    text-align: left;
+}
+
+.more {
+    width: 338px;
+    max-width: 100%;
+    margin: 0 auto;
+    padding: 0 15px;
+    box-sizing: content-box;
+}
+
+.moreButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 43px;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 20px;
+    letter-spacing: 0.005em;
+    color: #fff;
+    background-color: var(--color-bg-green);
+    border-radius: 5px;
+    transition: background-color var(--transition);
+}
+
+.moreButton:hover {
+    background-color: var(--color-green-hover);
+}
+
+.moreButton:active {
+    background-color: var(--color-green-dark);
+}
+
+@media (max-width: 1200px) {
+    .carousel {
+        grid-auto-columns: calc((100vw - 50px) / 2.5);
+    }
+}
+
+@media (max-width: 768px) {
+    .wrapper {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 20px;
+    }
+
+    .title {
+        font-size: 22px;
+        line-height: 32px;
+    }
+
+    .tabs {
+        width: 100%;
+    }
+
+    .tab {
+        font-size: 14px;
+    }
+
+    .carousel {
+        grid-auto-columns: 85%;
+        column-gap: 16px;
+        padding-left: 15px;
+        padding-right: 15px;
+        scroll-padding-left: 15px;
+    }
+
+    .cardTitle {
+        font-size: 16px;
+        line-height: 22px;
+    }
+}

--- a/apps/ncottage-www/src/components/sections/OurWorksSection/OurWorksSection.stories.tsx
+++ b/apps/ncottage-www/src/components/sections/OurWorksSection/OurWorksSection.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { OUR_WORKS_SECTION } from "@/lib/constants";
+import { getBuiltObjects } from "@/lib/data";
+import { OurWorksSection } from "./OurWorksSection";
+
+const meta: Meta<typeof OurWorksSection> = {
+    title: "Sections/OurWorksSection",
+    component: OurWorksSection,
+    parameters: { layout: "fullscreen" },
+    args: {
+        title: OUR_WORKS_SECTION.title,
+        tabs: OUR_WORKS_SECTION.tabs,
+        cta: OUR_WORKS_SECTION.cta,
+        objects: getBuiltObjects(),
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof OurWorksSection>;
+
+export const Desktop: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+};
+
+export const Tablet: Story = {
+    globals: { viewport: { value: "ipad", isRotated: false } },
+};
+
+export const Mobile: Story = {
+    globals: { viewport: { value: "iphone14", isRotated: false } },
+};

--- a/apps/ncottage-www/src/components/sections/OurWorksSection/OurWorksSection.tsx
+++ b/apps/ncottage-www/src/components/sections/OurWorksSection/OurWorksSection.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+import type {
+    OurWorksSectionContent,
+    OurWorksSectionTab,
+} from "@/lib/constants";
+import type { BuiltObject } from "@/types/common";
+import styles from "./OurWorksSection.module.css";
+
+interface OurWorksSectionProps {
+    title: OurWorksSectionContent["title"];
+    tabs: OurWorksSectionContent["tabs"];
+    cta: OurWorksSectionContent["cta"];
+    objects: BuiltObject[];
+}
+
+export function OurWorksSection({
+    title,
+    tabs,
+    cta,
+    objects,
+}: OurWorksSectionProps) {
+    function renderTab(tab: OurWorksSectionTab, index: number) {
+        const isActive = index === 0;
+        const className = isActive
+            ? `${styles.tab} ${styles.tabActive}`
+            : styles.tab;
+        if (tab.href) {
+            return (
+                <Link key={tab.id} href={tab.href} className={className}>
+                    {tab.label}
+                </Link>
+            );
+        }
+        return (
+            <span key={tab.id} className={className}>
+                {tab.label}
+            </span>
+        );
+    }
+
+    return (
+        <section className={styles.section}>
+            <div className={styles.wrapper}>
+                <h2 className={styles.title}>{title}</h2>
+                <div className={styles.tabs}>{tabs.map(renderTab)}</div>
+            </div>
+            <div className={styles.carousel}>
+                {objects.map((obj) => (
+                    <Link
+                        key={obj.id}
+                        href={obj.href}
+                        className={styles.card}
+                    >
+                        <img
+                            src={obj.image}
+                            alt={obj.title}
+                            className={styles.image}
+                            decoding="async"
+                        />
+                        <h3 className={styles.cardTitle}>{obj.title}</h3>
+                    </Link>
+                ))}
+            </div>
+            <div className={styles.more}>
+                <Link href={cta.href} className={styles.moreButton}>
+                    {cta.label}
+                </Link>
+            </div>
+        </section>
+    );
+}

--- a/apps/ncottage-www/src/components/sections/OurWorksSection/index.ts
+++ b/apps/ncottage-www/src/components/sections/OurWorksSection/index.ts
@@ -1,0 +1,1 @@
+export { OurWorksSection } from "./OurWorksSection";

--- a/apps/ncottage-www/src/data/built-objects.json
+++ b/apps/ncottage-www/src/data/built-objects.json
@@ -1,0 +1,74 @@
+[
+    {
+        "id": "nizhnie-oselki",
+        "title": "Дом из СИП панелей в пос. Нижние Осельки",
+        "image": "https://ncottage.ru/app/uploads/2020/05/6ad24f1f-b37b-4958-ba9f-4cddbefbcdf0.jpg",
+        "href": "/our-works/sip-dom-po-tipovomu-proektu-garden-v-p-nizhnie-oselki"
+    },
+    {
+        "id": "banya-levashovo",
+        "title": "Баня из СИП панелей",
+        "image": "https://ncottage.ru/app/uploads/2020/05/kuznecov.jpg",
+        "href": "/our-works/banya-iz-sip-panelej-p-levashovo"
+    },
+    {
+        "id": "severnaya-zhemchuzhina-2",
+        "title": "Каркасный дом в п. Северная Жемчужина",
+        "image": "https://ncottage.ru/app/uploads/2020/05/whatsapp20image202019-12-0320at2017.37.04.jpg",
+        "href": "/our-works/karkasnyj-dom-v-p-severnaya-zhemchuzhina-2"
+    },
+    {
+        "id": "priyutino",
+        "title": "Каркасный дом в п. Приютино",
+        "image": "https://ncottage.ru/app/uploads/2020/05/798b08fe-c82d-4e4b-823f-3d62e55f9b36-1.jpg",
+        "href": "/our-works/karkasnyj-dom-v-p-priyutino"
+    },
+    {
+        "id": "vyborg",
+        "title": "Дом из СИП панелей в г. Выборг",
+        "image": "https://ncottage.ru/app/uploads/2020/05/smirnova.jpg",
+        "href": "/our-works/dom-iz-sip-panelej-v-g-vyborg"
+    },
+    {
+        "id": "oliki",
+        "title": "Дом из газобетона с гаражом дер. Олики",
+        "image": "https://ncottage.ru/app/uploads/2020/05/dsc01272-scaled.jpg",
+        "href": "/our-works/dom-i-gazobetona-s-garazhom-der-oliki"
+    },
+    {
+        "id": "kanon",
+        "title": "Каркасный дом с отделкой фасадным камнем Каньон",
+        "image": "https://ncottage.ru/app/uploads/2020/03/pgb2favbgwu-e1591215656105.jpg",
+        "href": "/our-works/karkasnyj-dom-s-otdelkoj-fasadnym-kamnem-kanon"
+    },
+    {
+        "id": "podmoshe",
+        "title": "Дом из газобетона в дер. Подмошье",
+        "image": "https://ncottage.ru/app/uploads/2020/05/img_20191105_115323-scaled.jpg",
+        "href": "/our-works/dom-iz-gazobetona-v-der-podmoshe"
+    },
+    {
+        "id": "domodedovo",
+        "title": "Дом из поризованого кирпича в Домодедово",
+        "image": "https://ncottage.ru/app/uploads/2020/05/domoded_2.jpg",
+        "href": "/our-works/dom-iz-porizovanogo-kirpicha-v-domodedovo"
+    },
+    {
+        "id": "brick-house",
+        "title": "Дом из кирпича",
+        "image": "https://ncottage.ru/app/uploads/2020/05/920368020.jpg",
+        "href": "/our-works/dom-iz-kirpicha"
+    },
+    {
+        "id": "sestroretsk",
+        "title": "Дом из газобетона в Сестрорецке",
+        "image": "https://ncottage.ru/app/uploads/2020/05/37f59816106b6d16.jpg",
+        "href": "/our-works/dom-iz-gazobetona-v-sestroretske"
+    },
+    {
+        "id": "severnaya-zhemchuzhina",
+        "title": "Каркасный дом в п. Северная Жемчужина",
+        "image": "https://ncottage.ru/app/uploads/2020/05/whatsapp20image202019-12-0320at2017.37.03.jpg",
+        "href": "/our-works/karkasnyj-dom-v-p-severnaya-zhemchuzhina"
+    }
+]

--- a/apps/ncottage-www/src/lib/constants.ts
+++ b/apps/ncottage-www/src/lib/constants.ts
@@ -360,6 +360,30 @@ export const POPULAR_PROJECTS_SECTION: PopularProjectsSectionContent = {
     },
 };
 
+export type OurWorksSectionTab = {
+    id: string;
+    label: string;
+    href?: string;
+};
+
+export type OurWorksSectionContent = {
+    title: string;
+    tabs: OurWorksSectionTab[];
+    cta: { label: string; href: string };
+};
+
+export const OUR_WORKS_SECTION: OurWorksSectionContent = {
+    title: "Наши работы",
+    tabs: [
+        { id: "objects", label: "Построенные объекты" },
+        { id: "map", label: "Объекты на карте", href: "/map" },
+    ],
+    cta: {
+        label: "Смотреть все построенные объекты",
+        href: "/our-works",
+    },
+};
+
 export type ViewRequestSectionContent = {
     title: string;
     nameLabel: string;

--- a/apps/ncottage-www/src/lib/data.ts
+++ b/apps/ncottage-www/src/lib/data.ts
@@ -1,7 +1,13 @@
 import type { Project } from "@/types/project";
 import type { Service } from "@/types/service";
 import type { Review } from "@/types/review";
-import type { Advantage, Stage, GalleryItem, Category } from "@/types/common";
+import type {
+    Advantage,
+    Stage,
+    GalleryItem,
+    Category,
+    BuiltObject,
+} from "@/types/common";
 
 import projectsData from "@/data/projects.json";
 import servicesData from "@/data/services.json";
@@ -10,6 +16,7 @@ import advantagesData from "@/data/advantages.json";
 import stagesData from "@/data/stages.json";
 import galleryData from "@/data/gallery.json";
 import categoriesData from "@/data/categories.json";
+import builtObjectsData from "@/data/built-objects.json";
 
 export function getProjects(): Project[] {
     return projectsData as Project[];
@@ -49,4 +56,8 @@ export function getGallery(): GalleryItem[] {
 
 export function getCategories(): Category[] {
     return categoriesData as Category[];
+}
+
+export function getBuiltObjects(): BuiltObject[] {
+    return builtObjectsData as BuiltObject[];
 }

--- a/apps/ncottage-www/src/types/common.ts
+++ b/apps/ncottage-www/src/types/common.ts
@@ -24,3 +24,10 @@ export interface Category {
     image: string;
     technology: string;
 }
+
+export interface BuiltObject {
+    id: string;
+    title: string;
+    image: string;
+    href: string;
+}


### PR DESCRIPTION
Closes #65.

## Summary
- Новая секция `OurWorksSection` на главной (`apps/ncottage-www`) между `PopularProjects` и `StagesSection` — портирует `front-page__works` с ncottage.ru.
- Заголовок «Наши работы» + 414×43 segmented-табы «Построенные объекты» (активный) / «Объекты на карте» (Link на `/map`).
- Карточки 584:350 с фото-фоном, нижним градиентом, заголовком 20/700 поверх; hover увеличивает картинку `scale(1.06)`.
- Кнопка «Смотреть все построенные объекты» (`/our-works`), стиль `.front-page__works-button` (зелёная 338×43).
- Карусель — нативный `overflow-x: auto` + `scroll-snap-type: x mandatory`, `overscroll-behavior-x: contain` (отключает back/forward на macOS swipe). Без autoplay/loop — пробовали Embla и самописный transform-loop, оба давали глитчи; нативный scroll-snap надёжнее.
- Контент: 12 объектов в `data/built-objects.json`, тип `BuiltObject` в `types/common.ts`, getter `getBuiltObjects`.
- Storybook-стори: Desktop / Tablet / Mobile.

## Test plan
- [ ] `pnpm --filter @forge/ncottage-www typecheck`
- [ ] `pnpm --filter @forge/ncottage-www build`
- [ ] Storybook `Sections/OurWorksSection` — все три viewport стори.
- [ ] Dev-сервер: секция отрисована, тачпад двумя пальцами скроллит карусель горизонтально, страница не уходит на back/forward.
- [ ] На 1200- видны 2.5 карточки, на mobile (<768) — 1 + snap-scroll.
- [ ] Hover на карточку → картинка плавно увеличивается, заголовок не дёргается.