### PR TITLE
refactor: StagesSection parity with ncottage.ru

### DIFF
--- a/apps/ncottage-www/src/app/about/page.tsx
+++ b/apps/ncottage-www/src/app/about/page.tsx
@@ -3,7 +3,7 @@ import { Container } from "@/components/ui/Container";
 import { SectionHeading } from "@/components/ui/SectionHeading";
 import { AdvantagesSection } from "@/components/sections/AdvantagesSection";
 import { StagesSection } from "@/components/sections/StagesSection";
-import { ADVANTAGES_SECTION } from "@/lib/constants";
+import { ADVANTAGES_SECTION, STAGES_SECTION } from "@/lib/constants";
 import styles from "./page.module.css";
 
 export const metadata: Metadata = {
@@ -75,7 +75,10 @@ export default function AboutPage() {
                 background={ADVANTAGES_SECTION.background}
                 items={ADVANTAGES_SECTION.items}
             />
-            <StagesSection />
+            <StagesSection
+                title={STAGES_SECTION.title}
+                stages={STAGES_SECTION.stages}
+            />
         </>
     );
 }

--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -19,6 +19,7 @@ import {
     POPULAR_PROJECTS_SECTION,
     PROJECT_PICKER,
     QUIZ_SECTION,
+    STAGES_SECTION,
     VIEW_REQUEST_SECTION,
 } from "@/lib/constants";
 import {
@@ -103,7 +104,10 @@ export default function HomePage() {
                 cta={OUR_WORKS_SECTION.cta}
                 objects={builtObjects}
             />
-            <StagesSection />
+            <StagesSection
+                title={STAGES_SECTION.title}
+                stages={STAGES_SECTION.stages}
+            />
             <GallerySection items={gallery} />
             <ReviewsSection reviews={reviews} />
             <CtaSection />

--- a/apps/ncottage-www/src/components/sections/StagesSection/StagesSection.module.css
+++ b/apps/ncottage-www/src/components/sections/StagesSection/StagesSection.module.css
@@ -1,51 +1,198 @@
 .section {
-    padding: 60px 0;
-    background-color: var(--color-green);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    min-height: 280px;
+    padding: 43px 0 60px;
+    background: linear-gradient(
+        270deg,
+        rgba(71, 147, 50, 0.95) 0%,
+        rgba(71, 147, 50, 0.95) 53.09%,
+        rgba(71, 147, 50, 0.95) 100.93%
+    );
+    color: #fff;
+}
+
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    max-width: 1230px;
+    padding: 0 15px;
+    margin: 0 auto;
 }
 
 .title {
-    font-size: 30px;
-    font-weight: 700;
-    color: #fff;
-    text-align: center;
-    margin-bottom: 40px;
+    margin-bottom: 27px;
+    font-weight: 900;
+    font-size: 26px;
+    line-height: 45px;
+    text-transform: uppercase;
 }
 
-.grid {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    gap: 15px;
+.list {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
 }
 
 .item {
-    text-align: center;
-    padding: 20px 10px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    width: calc(100% / 6);
+    padding-left: 9px;
+    border-bottom: 2px solid #fff;
+}
+
+.item::after {
+    position: absolute;
+    bottom: -5px;
+    left: 0;
+    width: 10px;
+    height: 10px;
+    background-color: #479332;
+    border: 2px solid #fff;
+    border-radius: 50%;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.25);
+    box-sizing: border-box;
+    content: "";
+}
+
+.item:first-child::after {
+    background-color: #c4c4c4;
+}
+
+.item:last-child {
+    border-bottom: none;
+}
+
+.item:last-child::after {
+    bottom: -3px;
 }
 
 .num {
-    display: block;
-    font-size: 48px;
-    font-weight: 700;
-    color: rgba(255, 255, 255, 0.3);
-    line-height: 1;
-    margin-bottom: 10px;
+    margin-bottom: 16px;
+    font-weight: 900;
+    font-size: 34px;
+    line-height: 24px;
 }
 
 .itemTitle {
-    display: block;
-    font-size: 14px;
-    font-weight: 500;
-    color: #fff;
+    max-width: 110px;
+    margin-bottom: 20px;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 24px;
 }
 
-@media (max-width: 768px) {
-    .grid {
-        grid-template-columns: repeat(3, 1fr);
+@media (min-width: 769px) and (max-width: 989px) {
+    .section {
+        padding: 40px 0;
+    }
+
+    .title {
+        font-size: 24px;
+        line-height: 40px;
+        margin-bottom: 25px;
+    }
+
+    .item {
+        width: calc(100% / 5);
+    }
+
+    .itemTitle {
+        max-width: 100%;
     }
 }
 
-@media (max-width: 480px) {
-    .grid {
-        grid-template-columns: repeat(2, 1fr);
+@media (min-width: 660px) and (max-width: 768px) {
+    .section {
+        padding: 40px 0;
+    }
+
+    .title {
+        font-size: 24px;
+        line-height: 40px;
+        margin-bottom: 25px;
+    }
+
+    .item {
+        width: calc(100% / 5);
+    }
+
+    .num {
+        margin-bottom: 10px;
+    }
+
+    .itemTitle {
+        font-size: 18px;
+        max-width: 100%;
+    }
+}
+
+@media (max-width: 659px) {
+    .section {
+        padding: 38px 0;
+    }
+
+    .title {
+        font-size: 22px;
+        line-height: 35px;
+        margin-bottom: 27px;
+    }
+
+    .list {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .item {
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: flex-end;
+        width: 100%;
+        min-height: 30px;
+        margin-bottom: 20px;
+        padding-left: 19px;
+        border-bottom: none;
+    }
+
+    .item::before {
+        position: absolute;
+        bottom: 8px;
+        left: 0;
+        width: 2px;
+        height: 43px;
+        background-color: #fff;
+        content: "";
+    }
+
+    .item:first-child::before {
+        content: none;
+    }
+
+    .item::after {
+        bottom: 0;
+        left: -4px;
+    }
+
+    .item:last-child::after {
+        bottom: 0;
+    }
+
+    .num {
+        margin-right: 9px;
+        margin-bottom: 0;
+    }
+
+    .itemTitle {
+        max-width: 100%;
+        margin-bottom: 0;
+        font-size: 18px;
     }
 }

--- a/apps/ncottage-www/src/components/sections/StagesSection/StagesSection.stories.tsx
+++ b/apps/ncottage-www/src/components/sections/StagesSection/StagesSection.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { STAGES_SECTION } from "@/lib/constants";
+import { StagesSection } from "./StagesSection";
+
+const meta: Meta<typeof StagesSection> = {
+    title: "Sections/StagesSection",
+    component: StagesSection,
+    parameters: { layout: "fullscreen" },
+    args: {
+        title: STAGES_SECTION.title,
+        stages: STAGES_SECTION.stages,
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof StagesSection>;
+
+export const Desktop: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+};
+
+export const Tablet: Story = {
+    globals: { viewport: { value: "ipad", isRotated: false } },
+};
+
+export const Mobile: Story = {
+    globals: { viewport: { value: "iphone14", isRotated: false } },
+};

--- a/apps/ncottage-www/src/components/sections/StagesSection/StagesSection.tsx
+++ b/apps/ncottage-www/src/components/sections/StagesSection/StagesSection.tsx
@@ -1,31 +1,27 @@
-import { Container } from "@/components/ui/Container";
+import type { StagesSectionContent } from "@/lib/constants";
 import styles from "./StagesSection.module.css";
 
-const STAGES = [
-    { num: "01", title: "Встреча в офисе" },
-    { num: "02", title: "Заключение договора" },
-    { num: "03", title: "Разработка проекта" },
-    { num: "04", title: "Строительство дома" },
-    { num: "05", title: "Технический надзор" },
-    { num: "06", title: "Сдача дома" },
-];
+interface StagesSectionProps {
+    title: StagesSectionContent["title"];
+    stages: StagesSectionContent["stages"];
+}
 
-export function StagesSection() {
+export function StagesSection({ title, stages }: StagesSectionProps) {
     return (
         <section className={styles.section}>
-            <Container>
-                <h2 className={styles.title}>Этапы работы с нами</h2>
-                <div className={styles.grid}>
-                    {STAGES.map((stage) => (
+            <div className={styles.wrapper}>
+                <h2 className={styles.title}>{title}</h2>
+                <div className={styles.list}>
+                    {stages.map((stage) => (
                         <div key={stage.num} className={styles.item}>
-                            <span className={styles.num}>{stage.num}</span>
-                            <span className={styles.itemTitle}>
+                            <div className={styles.num}>{stage.num}</div>
+                            <div className={styles.itemTitle}>
                                 {stage.title}
-                            </span>
+                            </div>
                         </div>
                     ))}
                 </div>
-            </Container>
+            </div>
         </section>
     );
 }

--- a/apps/ncottage-www/src/lib/constants.ts
+++ b/apps/ncottage-www/src/lib/constants.ts
@@ -416,6 +416,28 @@ export const VIEW_REQUEST_SECTION: ViewRequestSectionContent = {
     successText: "Мы свяжемся с вами в течение 15 минут.",
 };
 
+export type StagesSectionStage = {
+    num: string;
+    title: string;
+};
+
+export type StagesSectionContent = {
+    title: string;
+    stages: StagesSectionStage[];
+};
+
+export const STAGES_SECTION: StagesSectionContent = {
+    title: "Этапы работы с нами",
+    stages: [
+        { num: "01", title: "Встреча в офисе" },
+        { num: "02", title: "Заключение договора" },
+        { num: "03", title: "Разработка проекта" },
+        { num: "04", title: "Строительство дома" },
+        { num: "05", title: "Технический надзор" },
+        { num: "06", title: "Сдача дома" },
+    ],
+};
+
 export type QuizSpeaker = {
     name: string;
     role: string;


### PR DESCRIPTION
Closes #67.

## Summary
- CSS `StagesSection` приведён к parity с `.front-page__green-row-stages`: 1230px wrapper, градиент-фон `linear-gradient(270deg, rgba(71,147,50,.95) ...)`, items 1/6 ширины с `border-bottom: 2px solid #fff` и точкой-маркером `::after` 10×10 (серая для первого, зелёная далее), без бордера у последнего, заголовок 26/45/900 uppercase.
- Брейкпоинты: 769–989 и 660–768 → items 1/5, title 24/40, item-title 18px; <660 — flex-column со штрихом `::before` 2×43 между точками, num и title в строку, 18px text.
- Данные вынесены в `lib/constants.ts` как `STAGES_SECTION` (`title` + `stages[]`) с типами `StagesSectionStage` / `StagesSectionContent` — по образцу `VIEW_REQUEST_SECTION`.
- Компонент параметризован пропсами `title` и `stages`, прокинут из `app/page.tsx` и `app/about/page.tsx`.
- Добавлена `StagesSection.stories.tsx` (Desktop / Tablet / Mobile), args из `STAGES_SECTION`.
- Убран `<Container>` (1170px) — собственный `.wrapper` с 1230px, как у `OurWorksSection`, чтобы попасть в эталон ширины.

## Test plan
- [ ] `pnpm --filter @forge/ncottage-www typecheck`
- [ ] `pnpm --filter @forge/ncottage-www build`
- [ ] Storybook `Sections/StagesSection` — Desktop / Tablet / Mobile.
- [ ] Dev-сервер: `/` и `/about` — секция отрисована, заголовок uppercase, точки выровнены с `border-bottom`, первая точка серая.
- [ ] На 660–989 — 5 items в строку (6-й заходит за край — поведение эталона), title без max-width 110px.
- [ ] На <660 — items в столбик, между ними вертикальная белая полоса, num и title в одной строке.