### PR TITLE
refactor: CtaSection parity with ncottage.ru

### DIFF
--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -13,6 +13,7 @@ import { ViewRequestSection } from "@/components/sections/ViewRequestSection";
 import {
     ADVANTAGES_SECTION,
     CATEGORIES_SECTION,
+    CTA_SECTION,
     HERO,
     OUR_WORKS_SECTION,
     POPULAR_PROJECTS_SECTION,
@@ -111,7 +112,12 @@ export default function HomePage() {
                 nextLabel={REVIEWS_SECTION.nextLabel}
                 reviews={REVIEWS_SECTION.reviews}
             />
-            <CtaSection />
+            <CtaSection
+                title={CTA_SECTION.title}
+                text={CTA_SECTION.text}
+                buttonLabel={CTA_SECTION.buttonLabel}
+                image={CTA_SECTION.image}
+            />
             <ContactForm />
         </>
     );

--- a/apps/ncottage-www/src/components/sections/CtaSection/CtaSection.module.css
+++ b/apps/ncottage-www/src/components/sections/CtaSection/CtaSection.module.css
@@ -1,40 +1,144 @@
 .section {
-    padding: 60px 0;
-    background-color: var(--color-green);
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-height: 318px;
+    padding: 43px 0 54px;
+    background: linear-gradient(
+        270deg,
+        rgba(71, 147, 50, 0.95) 0%,
+        rgba(71, 147, 50, 0.95) 53.09%,
+        rgba(71, 147, 50, 0.95) 100.93%
+    );
+    color: #fff;
 }
 
-.inner {
-    text-align: center;
+.wrapper {
+    position: relative;
+    width: 100%;
+    max-width: 1230px;
+    padding: 0 15px;
+    margin: 0 auto;
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    max-width: 670px;
 }
 
 .title {
-    font-size: 28px;
-    font-weight: 700;
-    color: #fff;
-    margin-bottom: 15px;
+    margin: 0 0 16px;
+    font-weight: 900;
+    font-size: 26px;
+    line-height: 40px;
+    text-transform: uppercase;
 }
 
 .text {
-    font-size: 15px;
-    color: rgba(255, 255, 255, 0.85);
-    margin-bottom: 30px;
+    margin-bottom: 26px;
+    font-size: 20px;
+    line-height: 28px;
+}
+
+.buttonRow {
+    width: 100%;
 }
 
 .button {
-    display: inline-block;
-    padding: 16px 40px;
-    font-size: 13px;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--color-green);
-    background-color: #fff;
-    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 400px;
+    height: 43px;
+    padding: 0;
+    background: #fff;
+    border: none;
+    border-radius: 5px;
+    outline: none;
     cursor: pointer;
-    transition: all var(--transition);
+    font-family: inherit;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 20px;
+    letter-spacing: 0.08px;
+    text-align: center;
+    color: #000;
+    transition: color var(--transition);
 }
 
 .button:hover {
-    background-color: var(--color-text-dark);
-    color: #fff;
+    color: var(--color-green-dark);
+    text-decoration: underline;
+}
+
+.button:active {
+    color: var(--color-green-dark);
+}
+
+.image {
+    position: absolute;
+    right: -68px;
+    bottom: -115px;
+}
+
+.imageImg {
+    height: 450px;
+    width: auto;
+}
+
+@media (min-width: 990px) and (max-width: 1230px) {
+    .image {
+        right: 0;
+        bottom: -35px;
+    }
+
+    .imageImg {
+        height: 300px;
+    }
+}
+
+@media (min-width: 769px) and (max-width: 989px) {
+    .content {
+        max-width: 100%;
+    }
+
+    .title {
+        text-align: center;
+    }
+
+    .image {
+        display: none;
+    }
+
+    .button {
+        margin: 0 auto;
+    }
+}
+
+@media (max-width: 768px) {
+    .section {
+        padding: 37px 0 46px;
+    }
+
+    .content {
+        max-width: 100%;
+    }
+
+    .title {
+        text-align: left;
+        font-size: 22px;
+        line-height: 35px;
+    }
+
+    .image {
+        display: none;
+    }
+
+    .button {
+        width: 100%;
+        margin: 0;
+        font-size: 15px;
+    }
 }

--- a/apps/ncottage-www/src/components/sections/CtaSection/CtaSection.stories.tsx
+++ b/apps/ncottage-www/src/components/sections/CtaSection/CtaSection.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CTA_SECTION } from "@/lib/constants";
+import { CtaSection } from "./CtaSection";
+
+const meta: Meta<typeof CtaSection> = {
+    title: "Sections/CtaSection",
+    component: CtaSection,
+    parameters: { layout: "fullscreen" },
+    args: {
+        title: CTA_SECTION.title,
+        text: CTA_SECTION.text,
+        buttonLabel: CTA_SECTION.buttonLabel,
+        image: CTA_SECTION.image,
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof CtaSection>;
+
+export const Desktop: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+};
+
+export const Tablet: Story = {
+    globals: { viewport: { value: "ipad", isRotated: false } },
+};
+
+export const Mobile: Story = {
+    globals: { viewport: { value: "iphone14", isRotated: false } },
+};

--- a/apps/ncottage-www/src/components/sections/CtaSection/CtaSection.tsx
+++ b/apps/ncottage-www/src/components/sections/CtaSection/CtaSection.tsx
@@ -1,21 +1,40 @@
-import { Container } from "@/components/ui/Container";
+import type { CtaSectionContent } from "@/lib/constants";
 import styles from "./CtaSection.module.css";
 
-export function CtaSection() {
+interface CtaSectionProps {
+    title: CtaSectionContent["title"];
+    text: CtaSectionContent["text"];
+    buttonLabel: CtaSectionContent["buttonLabel"];
+    image: CtaSectionContent["image"];
+}
+
+export function CtaSection({
+    title,
+    text,
+    buttonLabel,
+    image,
+}: CtaSectionProps) {
     return (
         <section className={styles.section}>
-            <Container className={styles.inner}>
-                <h2 className={styles.title}>
-                    Хотите оригинальный дом, не похожий ни на один другой?
-                </h2>
-                <p className={styles.text}>
-                    Закажите разработку индивидуального проекта с учетом всех
-                    ваших пожеланий и предпочтений!
-                </p>
-                <button className={styles.button}>
-                    Оставить заявку на проектирование
-                </button>
-            </Container>
+            <div className={styles.wrapper}>
+                <div className={styles.content}>
+                    <h2 className={styles.title}>{title}</h2>
+                    <div className={styles.text}>{text}</div>
+                    <div className={styles.buttonRow}>
+                        <button type="button" className={styles.button}>
+                            {buttonLabel}
+                        </button>
+                    </div>
+                </div>
+                <div className={styles.image}>
+                    <img
+                        className={styles.imageImg}
+                        src={image.src}
+                        alt={image.alt}
+                        decoding="async"
+                    />
+                </div>
+            </div>
         </section>
     );
 }

--- a/apps/ncottage-www/src/lib/constants.ts
+++ b/apps/ncottage-www/src/lib/constants.ts
@@ -416,6 +416,26 @@ export const VIEW_REQUEST_SECTION: ViewRequestSectionContent = {
     successText: "Мы свяжемся с вами в течение 15 минут.",
 };
 
+export type CtaSectionContent = {
+    title: string;
+    text: string;
+    buttonLabel: string;
+    image: {
+        src: string;
+        alt: string;
+    };
+};
+
+export const CTA_SECTION: CtaSectionContent = {
+    title: "Хотите оригинальный дом, не похожий ни на один другой?",
+    text: "Закажите разработку индивидуального проекта с учетом всех ваших пожеланий и предпочтений!",
+    buttonLabel: "Оставить заявку на проектирование",
+    image: {
+        src: "https://ncottage.ru/app/uploads/2019/10/house.png",
+        alt: "Проект дома",
+    },
+};
+
 export type Review = {
     id: string;
     author: string;


### PR DESCRIPTION
Closes #73.

## Summary
- `CtaSection` приведён к parity с `.front-page__green-row-request`: section min-h 318 padding 43/0/54, тот же градиент 270deg `rgba(71,147,50,.95)` что у `ViewRequestSection`/`StagesSection`; wrapper 1230 position relative; content max-w 670 left-aligned; title 26/40/900 uppercase; text 20/28; image absolute right -68 bottom -115 height 450 (overflow за нижний край).
- Кнопка 400×43 white radius 5, чёрный текст 16/20/500 с letter-spacing 0.08 (повторяет `.front-page__green-row-request_button`); hover/active — зелёный текст с подчёркиванием.
- Брейкпоинты: 990–1230 → image right 0 bottom -35 height 300; 769–989 → image скрыт, content max-w 100, title centered, button auto-margin; <768 → image скрыт, padding 37/0/46, title 22/35 left-aligned, button 100% width font 15.
- В `lib/constants.ts` добавлены `CtaSectionContent` и `CTA_SECTION` (`title`, `text`, `buttonLabel`, `image: { src, alt }`); компонент параметризован пропсами; прокинут из `app/page.tsx`.
- Image использует прямой URL `https://ncottage.ru/app/uploads/2019/10/house.png` (как в built-objects.json и REVIEWS_SECTION).
- Storybook-стори `Sections/CtaSection` (Desktop / Tablet / Mobile).

## Caveat
Кнопка — `<button type="button">` без обработчика. Эталон навешивает `data-fancybox` + `open_ajax_form` (Contact Form 7 ID=1591), у нас этой инфраструктуры нет — модалка отдельной задачей.

## Test plan
- [ ] `pnpm --filter @forge/ncottage-www typecheck`
- [ ] `pnpm --filter @forge/ncottage-www build`
- [ ] Storybook `Sections/CtaSection` — Desktop / Tablet / Mobile.
- [ ] Dev `/`: секция с зелёным фоном между `ReviewsSection` и `ContactForm`; на десктопе видно крупное PNG дома справа, заходящее за нижний край.
- [ ] На 1230- → image меньше (300px) и не свисает; на 989- → image скрыт, текст по центру; на <768 → кнопка во всю ширину.
- [ ] Hover на кнопку — текст становится зелёным с подчёркиванием.