### PR TITLE
refactor: ContactForm parity with ncottage.ru

### DIFF
--- a/apps/ncottage-www/src/app/contacts/page.tsx
+++ b/apps/ncottage-www/src/app/contacts/page.tsx
@@ -2,7 +2,13 @@ import type { Metadata } from "next";
 import { Container } from "@/components/ui/Container";
 import { SectionHeading } from "@/components/ui/SectionHeading";
 import { ContactForm } from "@/components/sections/ContactForm";
-import { PHONES, EMAIL, ADDRESSES, WORK_HOURS } from "@/lib/constants";
+import {
+    ADDRESSES,
+    CONTACT_FORM,
+    EMAIL,
+    PHONES,
+    WORK_HOURS,
+} from "@/lib/constants";
 import styles from "./page.module.css";
 
 export const metadata: Metadata = {
@@ -55,7 +61,21 @@ export default function ContactsPage() {
                     </div>
                 </Container>
             </section>
-            <ContactForm />
+            <ContactForm
+                title={CONTACT_FORM.title}
+                subtitle={CONTACT_FORM.subtitle}
+                nameLabel={CONTACT_FORM.nameLabel}
+                namePlaceholder={CONTACT_FORM.namePlaceholder}
+                phoneLabel={CONTACT_FORM.phoneLabel}
+                phonePlaceholder={CONTACT_FORM.phonePlaceholder}
+                messageLabel={CONTACT_FORM.messageLabel}
+                messagePlaceholder={CONTACT_FORM.messagePlaceholder}
+                submitLabel={CONTACT_FORM.submitLabel}
+                privacy={CONTACT_FORM.privacy}
+                image={CONTACT_FORM.image}
+                successTitle={CONTACT_FORM.successTitle}
+                successText={CONTACT_FORM.successText}
+            />
         </>
     );
 }

--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -13,6 +13,7 @@ import { ViewRequestSection } from "@/components/sections/ViewRequestSection";
 import {
     ADVANTAGES_SECTION,
     CATEGORIES_SECTION,
+    CONTACT_FORM,
     CTA_SECTION,
     HERO,
     OUR_WORKS_SECTION,
@@ -118,7 +119,21 @@ export default function HomePage() {
                 buttonLabel={CTA_SECTION.buttonLabel}
                 image={CTA_SECTION.image}
             />
-            <ContactForm />
+            <ContactForm
+                title={CONTACT_FORM.title}
+                subtitle={CONTACT_FORM.subtitle}
+                nameLabel={CONTACT_FORM.nameLabel}
+                namePlaceholder={CONTACT_FORM.namePlaceholder}
+                phoneLabel={CONTACT_FORM.phoneLabel}
+                phonePlaceholder={CONTACT_FORM.phonePlaceholder}
+                messageLabel={CONTACT_FORM.messageLabel}
+                messagePlaceholder={CONTACT_FORM.messagePlaceholder}
+                submitLabel={CONTACT_FORM.submitLabel}
+                privacy={CONTACT_FORM.privacy}
+                image={CONTACT_FORM.image}
+                successTitle={CONTACT_FORM.successTitle}
+                successText={CONTACT_FORM.successText}
+            />
         </>
     );
 }

--- a/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.module.css
+++ b/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.module.css
@@ -9,11 +9,11 @@
 .wrapper {
     position: relative;
     display: flex;
-    flex-direction: row-reverse;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: stretch;
     width: 100%;
     max-width: 1230px;
+    min-height: 482px;
     margin: 0 auto;
     background: #f8f8f8;
     border-radius: 5px;
@@ -21,16 +21,6 @@
 }
 
 .photo {
-    position: relative;
-    width: 100%;
-    max-width: 50%;
-    max-height: 482px;
-    overflow: hidden;
-    border-bottom-left-radius: 5px;
-    border-top-left-radius: 5px;
-}
-
-.photoImg {
     position: absolute;
     left: 0;
     bottom: 0;
@@ -242,8 +232,7 @@
 
 @media (max-width: 989px) {
     .wrapper {
-        flex-direction: column;
-        align-items: stretch;
+        min-height: 0;
     }
 
     .photo {

--- a/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.module.css
+++ b/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.module.css
@@ -138,7 +138,7 @@
     border-radius: 5px;
     outline: none;
     appearance: none;
-    resize: vertical;
+    resize: none;
     font-family: inherit;
     font-weight: 400;
     font-size: 16px;

--- a/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.module.css
+++ b/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.module.css
@@ -1,100 +1,309 @@
 .section {
-    padding: var(--section-padding);
-    background-color: #f8f8f8;
-}
-
-.inner {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 50px;
-    align-items: center;
-}
-
-.benefits {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    align-items: center;
+    width: 100%;
+    padding: 59px 0;
 }
 
-.benefits li {
-    font-size: 14px;
-    color: var(--color-text);
-    padding-left: 20px;
+.wrapper {
     position: relative;
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+    align-items: stretch;
+    width: 100%;
+    max-width: 1230px;
+    margin: 0 auto;
+    background: #f8f8f8;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
-.benefits li::before {
-    content: "";
+.photo {
+    position: relative;
+    width: 100%;
+    max-width: 50%;
+    max-height: 482px;
+    overflow: hidden;
+    border-bottom-left-radius: 5px;
+    border-top-left-radius: 5px;
+}
+
+.photoImg {
     position: absolute;
     left: 0;
-    top: 7px;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background-color: var(--color-green);
+    bottom: 0;
+    width: 100%;
+    max-width: 723px;
+    max-height: 482px;
+    height: auto;
+    object-fit: cover;
+    z-index: 1;
 }
 
 .formWrapper {
-    padding: 35px;
-    background-color: #fff;
-    border: 1px solid var(--color-border);
-    border-radius: 5px;
+    position: relative;
+    z-index: 2;
+    width: 100%;
+    max-width: 60%;
 }
 
 .form {
+    width: 100%;
+    padding: 25px;
+    border-radius: 5px;
+}
+
+.formTitle {
+    margin-bottom: 10px;
+    font-weight: 900;
+    font-size: 24px;
+    line-height: 29px;
+    text-transform: uppercase;
+    color: #535353;
+}
+
+.formSubtitle {
+    margin-bottom: 28px;
+    font-weight: 500;
+    font-size: 20px;
+    line-height: 26px;
+    color: #535353;
+    letter-spacing: 0.08px;
+}
+
+.formGrid {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    width: 100%;
+}
+
+.rows,
+.text {
     display: flex;
     flex-direction: column;
-    gap: 15px;
+    align-items: flex-start;
+    width: 100%;
+    max-width: calc((100% - 14px) / 2);
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.field + .field {
+    margin-top: 20px;
+}
+
+.srOnly {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .input {
-    padding: 12px 15px;
-    font-size: 14px;
-    background-color: #f8f8f8;
-    border: 1px solid var(--color-border);
-    border-radius: 4px;
-    color: var(--color-text-dark);
-    transition: border-color var(--transition);
+    width: 100%;
+    height: 48px;
+    padding-left: 23.5px;
+    background: #fff;
+    border: 1px solid #b7b7b7;
+    border-radius: 5px;
+    outline: none;
+    appearance: none;
+    font-family: inherit;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 19.5px;
+    letter-spacing: 0.08px;
+    color: var(--color-text);
 }
 
 .input::placeholder {
     color: var(--color-text-light);
+    opacity: 1;
 }
 
 .input:focus {
-    border-color: var(--color-green);
+    border-color: var(--color-bg-green);
 }
 
-.privacy {
-    font-size: 11px;
-    color: var(--color-text-light);
-    line-height: 1.5;
-}
-
-.privacy a {
-    color: var(--color-green);
-    text-decoration: underline;
-}
-
-.success {
-    text-align: center;
-    padding: 30px 0;
-}
-
-.successTitle {
-    font-size: 20px;
-    font-weight: 600;
-    color: var(--color-green);
-    margin-bottom: 8px;
-}
-
-.successText {
+.textarea {
+    width: 100%;
+    height: 116px;
+    padding: 13px 23.5px;
+    background: #fff;
+    border: 1px solid #b7b7b7;
+    border-radius: 5px;
+    outline: none;
+    appearance: none;
+    resize: vertical;
+    font-family: inherit;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 19.5px;
+    letter-spacing: 0.08px;
     color: var(--color-text);
 }
 
-@media (max-width: 768px) {
-    .inner {
-        grid-template-columns: 1fr;
-        gap: 25px;
+.textarea::placeholder {
+    color: var(--color-text-light);
+    opacity: 1;
+}
+
+.textarea:focus {
+    border-color: var(--color-bg-green);
+}
+
+.privacy {
+    width: 100%;
+    max-width: calc((100% - 14px) / 2);
+    margin-top: 15px;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 16px;
+    color: var(--color-text);
+}
+
+.privacyLink {
+    color: var(--color-text);
+    text-decoration: underline;
+}
+
+.privacyLink:hover {
+    text-decoration: none;
+}
+
+.submitWrap {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    max-width: calc((100% - 14px) / 2);
+    margin-top: 15px;
+}
+
+.submit {
+    width: 100%;
+    height: 48px;
+    background: var(--color-green);
+    border: none;
+    border-radius: 5px;
+    outline: none;
+    appearance: none;
+    cursor: pointer;
+    font-family: inherit;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 33px;
+    letter-spacing: 0.08px;
+    text-align: center;
+    color: #fff;
+    transition: background-color var(--transition);
+}
+
+.submit:hover {
+    background: var(--color-green-hover);
+}
+
+.submit:active {
+    background: var(--color-green-dark);
+}
+
+.success {
+    width: 100%;
+    padding: 40px 25px;
+    text-align: center;
+    color: var(--color-text);
+}
+
+.successTitle {
+    margin-bottom: 8px;
+    font-weight: 900;
+    font-size: 22px;
+    line-height: 28px;
+    text-transform: uppercase;
+}
+
+.successText {
+    font-size: 16px;
+    line-height: 24px;
+}
+
+@media (max-width: 989px) {
+    .wrapper {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .photo {
+        display: none;
+    }
+
+    .formWrapper {
+        max-width: 100%;
+    }
+}
+
+@media (max-width: 559px) {
+    .section {
+        padding: 34px 0;
+    }
+
+    .wrapper {
+        background: transparent;
+        box-shadow: none;
+        border-radius: 0;
+        padding: 0 15px;
+    }
+
+    .form {
+        padding: 28px 15px 35px;
+        background: #f8f8f8;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    }
+
+    .formTitle {
+        font-size: 22px;
+        line-height: 29px;
+        margin-bottom: 5px;
+    }
+
+    .formSubtitle {
+        margin-bottom: 24px;
+        font-size: 16px;
+        line-height: 23px;
+    }
+
+    .formGrid {
+        flex-direction: column;
+    }
+
+    .rows,
+    .text,
+    .privacy,
+    .submitWrap {
+        max-width: 100%;
+    }
+
+    .text,
+    .privacy,
+    .submitWrap {
+        margin-top: 15px;
+    }
+
+    .submit {
+        height: 43px;
+        line-height: 33px;
     }
 }

--- a/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.stories.tsx
+++ b/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CONTACT_FORM } from "@/lib/constants";
+import { ContactForm } from "./ContactForm";
+
+const meta: Meta<typeof ContactForm> = {
+    title: "Sections/ContactForm",
+    component: ContactForm,
+    parameters: { layout: "fullscreen" },
+    args: {
+        title: CONTACT_FORM.title,
+        subtitle: CONTACT_FORM.subtitle,
+        nameLabel: CONTACT_FORM.nameLabel,
+        namePlaceholder: CONTACT_FORM.namePlaceholder,
+        phoneLabel: CONTACT_FORM.phoneLabel,
+        phonePlaceholder: CONTACT_FORM.phonePlaceholder,
+        messageLabel: CONTACT_FORM.messageLabel,
+        messagePlaceholder: CONTACT_FORM.messagePlaceholder,
+        submitLabel: CONTACT_FORM.submitLabel,
+        privacy: CONTACT_FORM.privacy,
+        image: CONTACT_FORM.image,
+        successTitle: CONTACT_FORM.successTitle,
+        successText: CONTACT_FORM.successText,
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof ContactForm>;
+
+export const Desktop: Story = {
+    globals: { viewport: { value: "1440-900", isRotated: false } },
+};
+
+export const Tablet: Story = {
+    globals: { viewport: { value: "ipad", isRotated: false } },
+};
+
+export const Mobile: Story = {
+    globals: { viewport: { value: "iphone14", isRotated: false } },
+};

--- a/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.tsx
+++ b/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.tsx
@@ -50,14 +50,12 @@ export function ContactForm({
     return (
         <section className={styles.section}>
             <div className={styles.wrapper}>
-                <div className={styles.photo}>
-                    <img
-                        className={styles.photoImg}
-                        src={image.src}
-                        alt={image.alt}
-                        decoding="async"
-                    />
-                </div>
+                <img
+                    className={styles.photo}
+                    src={image.src}
+                    alt={image.alt}
+                    decoding="async"
+                />
                 <div className={styles.formWrapper}>
                     {submitted ? (
                         <div className={styles.success} role="status">

--- a/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.tsx
+++ b/apps/ncottage-www/src/components/sections/ContactForm/ContactForm.tsx
@@ -1,85 +1,156 @@
 "use client";
 
 import { useState } from "react";
-import { Container } from "@/components/ui/Container";
-import { SectionHeading } from "@/components/ui/SectionHeading";
-import { Button } from "@/components/ui/Button";
+import type { ContactFormContent } from "@/lib/constants";
 import styles from "./ContactForm.module.css";
 
-export function ContactForm() {
+interface ContactFormProps {
+    title: ContactFormContent["title"];
+    subtitle: ContactFormContent["subtitle"];
+    nameLabel: ContactFormContent["nameLabel"];
+    namePlaceholder: ContactFormContent["namePlaceholder"];
+    phoneLabel: ContactFormContent["phoneLabel"];
+    phonePlaceholder: ContactFormContent["phonePlaceholder"];
+    messageLabel: ContactFormContent["messageLabel"];
+    messagePlaceholder: ContactFormContent["messagePlaceholder"];
+    submitLabel: ContactFormContent["submitLabel"];
+    privacy: ContactFormContent["privacy"];
+    image: ContactFormContent["image"];
+    successTitle: ContactFormContent["successTitle"];
+    successText: ContactFormContent["successText"];
+}
+
+export function ContactForm({
+    title,
+    subtitle,
+    nameLabel,
+    namePlaceholder,
+    phoneLabel,
+    phonePlaceholder,
+    messageLabel,
+    messagePlaceholder,
+    submitLabel,
+    privacy,
+    image,
+    successTitle,
+    successText,
+}: ContactFormProps) {
     const [name, setName] = useState("");
     const [phone, setPhone] = useState("");
+    const [message, setMessage] = useState("");
     const [submitted, setSubmitted] = useState(false);
 
-    function handleSubmit(e: React.FormEvent) {
-        e.preventDefault();
-        if (!name.trim() || !phone.trim()) return;
-        console.log("Contact form:", { name, phone });
+    function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!phone.trim()) return;
+        console.log("ContactForm submit:", { name, phone, message });
         setSubmitted(true);
     }
 
     return (
         <section className={styles.section}>
-            <Container>
-                <div className={styles.inner}>
-                    <div className={styles.info}>
-                        <SectionHeading
-                            align="left"
-                            label="Обратная связь"
-                            title="Оставьте заявку"
-                            description="Мы свяжемся с вами в течение 30 минут в рабочее время и ответим на все вопросы."
-                        />
-                        <ul className={styles.benefits}>
-                            <li>Бесплатная консультация</li>
-                            <li>Расчёт стоимости за 24 часа</li>
-                            <li>Выезд на участок</li>
-                        </ul>
-                    </div>
-                    <div className={styles.formWrapper}>
-                        {submitted ? (
-                            <div className={styles.success}>
-                                <p className={styles.successTitle}>
-                                    Заявка отправлена
-                                </p>
-                                <p className={styles.successText}>
-                                    Мы свяжемся с вами в ближайшее время.
-                                </p>
+            <div className={styles.wrapper}>
+                <div className={styles.photo}>
+                    <img
+                        className={styles.photoImg}
+                        src={image.src}
+                        alt={image.alt}
+                        decoding="async"
+                    />
+                </div>
+                <div className={styles.formWrapper}>
+                    {submitted ? (
+                        <div className={styles.success} role="status">
+                            <p className={styles.successTitle}>
+                                {successTitle}
+                            </p>
+                            <p className={styles.successText}>{successText}</p>
+                        </div>
+                    ) : (
+                        <form
+                            className={styles.form}
+                            onSubmit={handleSubmit}
+                            noValidate
+                        >
+                            <div className={styles.formTitle}>{title}</div>
+                            <div className={styles.formSubtitle}>
+                                {subtitle}
                             </div>
-                        ) : (
-                            <form
-                                className={styles.form}
-                                onSubmit={handleSubmit}
-                            >
-                                <input
-                                    className={styles.input}
-                                    type="text"
-                                    placeholder="Ваше имя"
-                                    value={name}
-                                    onChange={(e) => setName(e.target.value)}
-                                    required
-                                />
-                                <input
-                                    className={styles.input}
-                                    type="tel"
-                                    placeholder="Телефон"
-                                    value={phone}
-                                    onChange={(e) => setPhone(e.target.value)}
-                                    required
-                                />
-                                <Button type="submit" size="lg">
-                                    Отправить заявку
-                                </Button>
+                            <div className={styles.formGrid}>
+                                <div className={styles.rows}>
+                                    <label className={styles.field}>
+                                        <span className={styles.srOnly}>
+                                            {nameLabel}
+                                        </span>
+                                        <input
+                                            className={styles.input}
+                                            type="text"
+                                            name="name"
+                                            autoComplete="name"
+                                            placeholder={namePlaceholder}
+                                            value={name}
+                                            onChange={(event) =>
+                                                setName(event.target.value)
+                                            }
+                                        />
+                                    </label>
+                                    <label className={styles.field}>
+                                        <span className={styles.srOnly}>
+                                            {phoneLabel}
+                                        </span>
+                                        <input
+                                            className={styles.input}
+                                            type="tel"
+                                            name="phone"
+                                            autoComplete="tel"
+                                            placeholder={phonePlaceholder}
+                                            value={phone}
+                                            onChange={(event) =>
+                                                setPhone(event.target.value)
+                                            }
+                                            required
+                                        />
+                                    </label>
+                                </div>
+                                <div className={styles.text}>
+                                    <label className={styles.field}>
+                                        <span className={styles.srOnly}>
+                                            {messageLabel}
+                                        </span>
+                                        <textarea
+                                            className={styles.textarea}
+                                            name="message"
+                                            rows={4}
+                                            placeholder={messagePlaceholder}
+                                            value={message}
+                                            onChange={(event) =>
+                                                setMessage(event.target.value)
+                                            }
+                                        />
+                                    </label>
+                                </div>
                                 <p className={styles.privacy}>
-                                    Нажимая кнопку, вы соглашаетесь с{" "}
-                                    <a href="/privacy">
-                                        политикой обработки персональных данных
+                                    {privacy.text}{" "}
+                                    <a
+                                        className={styles.privacyLink}
+                                        href={privacy.linkHref}
+                                    >
+                                        {privacy.linkLabel}
                                     </a>
                                 </p>
-                            </form>
-                        )}
-                    </div>
+                                <div className={styles.submitWrap}>
+                                    <button
+                                        type="submit"
+                                        className={styles.submit}
+                                    >
+                                        {submitLabel}
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    )}
                 </div>
-            </Container>
+            </div>
         </section>
     );
 }

--- a/apps/ncottage-www/src/lib/constants.ts
+++ b/apps/ncottage-www/src/lib/constants.ts
@@ -416,6 +416,52 @@ export const VIEW_REQUEST_SECTION: ViewRequestSectionContent = {
     successText: "Мы свяжемся с вами в течение 15 минут.",
 };
 
+export type ContactFormContent = {
+    title: string;
+    subtitle: string;
+    nameLabel: string;
+    namePlaceholder: string;
+    phoneLabel: string;
+    phonePlaceholder: string;
+    messageLabel: string;
+    messagePlaceholder: string;
+    submitLabel: string;
+    privacy: {
+        text: string;
+        linkLabel: string;
+        linkHref: string;
+    };
+    image: {
+        src: string;
+        alt: string;
+    };
+    successTitle: string;
+    successText: string;
+};
+
+export const CONTACT_FORM: ContactFormContent = {
+    title: "Остались вопросы?",
+    subtitle: "Оставьте номер телефона, мы перезвоним Вам в течение 15 минут!",
+    nameLabel: "Ваше имя",
+    namePlaceholder: "Ваше имя",
+    phoneLabel: "Телефон",
+    phonePlaceholder: "Телефон *",
+    messageLabel: "Сообщение",
+    messagePlaceholder: "Сообщение",
+    submitLabel: "Задать вопрос специалистам",
+    privacy: {
+        text: 'Нажимая на кнопку "Задать вопрос специалистам", вы даете согласие на обработку своих персональных данных. Ознакомиться с',
+        linkLabel: "политикой конфиденциальности.",
+        linkHref: "/privacy",
+    },
+    image: {
+        src: "https://ncottage.ru/app/themes/sage/dist/images/svg/devyshka-photo-form.svg",
+        alt: "Менеджер по работе с клиентами",
+    },
+    successTitle: "Заявка отправлена",
+    successText: "Мы свяжемся с вами в течение 15 минут.",
+};
+
 export type CtaSectionContent = {
     title: string;
     text: string;


### PR DESCRIPTION
Closes #75.

## Summary
- `ContactForm` приведён к parity с `.template-landing-page__contacts`: section padding 59/0; wrapper-карточка `flex-direction: row-reverse` с `bg #f8f8f8`, `border-radius: 5`, `box-shadow: 0 2px 5px rgba(0,0,0,.2)`; фото слева (`max-w 50%`, `position: relative`, `<img position: absolute; left:0; bottom:0; max-w 723; max-h 482`); форма справа `max-w 60%`, `padding 25`, `z-index 2`.
- Внутри формы: title 24/29/900 uppercase #535353 `mb 10`, subtitle 20/26/500 #535353 `mb 28`; flex row wrap `justify space-between`; rows (имя+телефон) и text (textarea) — `max-w: calc((100% - 14px) / 2)`; input 48 height `border 1px #b7b7b7 radius 5` 16/19.5; textarea 116 height; privacy 12/16 #535353 `mt 15` max-w 50%; submit 48 height `bg #479332` white 16/33/500 `letter-spacing 0.08`, hover #52A73A active #438630.
- Брейкпоинты: <989 — фото скрыто, форма max-w 100%; <559 — section padding 34/0, wrapper transparent без shadow и radius (padding 0/15), форма получает свой shadow/radius/padding 28/15/35, formGrid в столбик, всё max-w 100, submit 43.
- В `lib/constants.ts` — `CONTACT_FORM` (`title`, `subtitle`, `name/phone/messageLabel+Placeholder`, `submitLabel`, `privacy: { text, linkLabel, linkHref }`, `image: { src, alt }`, `successTitle/Text`) + тип `ContactFormContent`.
- Компонент параметризован пропсами, прокинут из `app/page.tsx` и `app/contacts/page.tsx`.
- Storybook-стори `Sections/ContactForm` (Desktop / Tablet / Mobile).
- Image — external URL `https://ncottage.ru/app/themes/sage/dist/images/svg/devyshka-photo-form.svg` (как в built-objects/REVIEWS_SECTION/CTA_SECTION).

## Caveat
Сабмит — `console.log` + success-стейт (как в `ViewRequestSection`). Реальная отправка / интеграция с Contact Form 7 (`#wpcf7-f1661`) — отдельная задача; на эталоне форма отправляется на `/?wpcf7=1661` через AJAX с reCAPTCHA, у нас бэкенда нет.

## Test plan
- [ ] `pnpm --filter @forge/ncottage-www typecheck`
- [ ] `pnpm --filter @forge/ncottage-www build`
- [ ] Storybook `Sections/ContactForm` — Desktop / Tablet / Mobile.
- [ ] Dev `/`: внизу страницы карточка с фото девушки слева, форма справа; на десктопе видно `bg #f8f8f8` с тенью.
- [ ] `/contacts`: то же самое под секцией с адресами.
- [ ] На <989 — фото скрыто, форма во всю ширину; на <559 — wrapper становится прозрачным, форма-карточка собирает свой `bg`/shadow.
- [ ] Сабмит без телефона не делает ничего; с телефоном — показывается success-блок.
- [ ] Hover на submit — фон становится #52A73A; active — #438630.