### PR TITLE
test: Add Playwright e2e smoke harness and browser MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ storybook-static/
 # Testing
 coverage/
 .nyc_output/
+playwright-report/
+test-results/
+blob-report/
+e2e/screenshots/
+.playwright-mcp/
 
 # Environment variables
 .env

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+    "mcpServers": {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@0.0.76", "--browser", "chromium"]
+        }
+    }
+}

--- a/apps/ncottage-www/e2e/routes.ts
+++ b/apps/ncottage-www/e2e/routes.ts
@@ -1,0 +1,59 @@
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appDir = join(here, "..", "src", "app");
+
+// Recursively collect routes that have a page.tsx, skipping dynamic segments
+// (handled by explicit samples below) and Next.js route groups `(group)`.
+function collectStaticRoutes(dir: string, base = ""): string[] {
+    const routes: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const name = entry.name;
+        if (name.startsWith("[") || name.startsWith("_") || name.startsWith(".")) {
+            continue;
+        }
+        const childDir = join(dir, name);
+        // Route groups don't add a path segment.
+        const segment = name.startsWith("(") ? base : `${base}/${name}`;
+        const hasPage = readdirSync(childDir).some(
+            (f) => f === "page.tsx" || f === "page.ts",
+        );
+        if (hasPage && !name.startsWith("(")) routes.push(segment);
+        routes.push(...collectStaticRoutes(childDir, segment));
+    }
+    return routes;
+}
+
+// One representative sample per dynamic segment keeps the crawl meaningful
+// without exploding into every slug. Sourced from src/app/**/*.ts data files.
+const dynamicRoutes = [
+    "/project/nord",
+    "/project/alaster",
+    "/projects/all",
+    "/projects/gas-concrete",
+    "/projects/brick",
+    "/projects/frame",
+    "/projects/sip",
+    "/projects/fachwerk",
+    "/services/design",
+    "/services/construction",
+    "/services/foundations",
+    "/services/engineering",
+    "/services/finishing",
+    "/services/baths",
+    "/services/commercial",
+    "/services/landscaping",
+    "/project-selections/zagorodnye-doma",
+    "/project-selections/odnoetazhnye-doma",
+    "/promos/frame-houses-special-price",
+    "/promos/gas-concrete-houses-special-price",
+    "/blog/kak-vybrat-tehnologiyu-doma",
+    "/blog/etapy-stroitelstva-doma",
+];
+
+export const routes: string[] = [
+    ...new Set(["/", ...collectStaticRoutes(appDir), ...dynamicRoutes]),
+].sort();

--- a/apps/ncottage-www/e2e/smoke.spec.ts
+++ b/apps/ncottage-www/e2e/smoke.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+
+import { routes } from "./routes";
+
+// Console / network noise that is not an app defect.
+const IGNORED_MESSAGES = [
+    "Download the React DevTools",
+    "favicon.ico",
+    "[Fast Refresh]",
+];
+
+const IGNORED_REQUESTS = ["/favicon.ico", "/_next/static/webpack/"];
+
+function isIgnored(text: string, list: string[]): boolean {
+    return list.some((needle) => text.includes(needle));
+}
+
+// localhost and 127.0.0.1 are the same host for our purposes; normalize so a
+// stray absolute link to the other form isn't dropped as "cross-origin".
+function normalizeHost(host: string): string {
+    return host === "127.0.0.1" ? "localhost" : host;
+}
+
+function isSameOrigin(url: string, base: string): boolean {
+    try {
+        const a = new URL(url);
+        const b = new URL(base);
+        return (
+            a.protocol === b.protocol &&
+            a.port === b.port &&
+            normalizeHost(a.hostname) === normalizeHost(b.hostname)
+        );
+    } catch {
+        return false;
+    }
+}
+
+test.describe("smoke: every route renders cleanly", () => {
+    for (const route of routes) {
+        test(`route ${route}`, async ({ page, baseURL }, testInfo) => {
+            const consoleErrors: string[] = [];
+            const pageErrors: string[] = [];
+            const failedRequests: string[] = [];
+
+            page.on("console", (msg) => {
+                if (msg.type() !== "error") return;
+                const text = msg.text();
+                if (!isIgnored(text, IGNORED_MESSAGES)) consoleErrors.push(text);
+            });
+            page.on("pageerror", (err) => {
+                pageErrors.push(err.message);
+            });
+            page.on("response", (res) => {
+                const status = res.status();
+                const url = res.url();
+                if (status < 400) return;
+                if (baseURL && !isSameOrigin(url, baseURL)) return; // only same-origin
+                if (isIgnored(url, IGNORED_REQUESTS)) return;
+                failedRequests.push(`${status} ${url}`);
+            });
+
+            const response = await page.goto(route, { waitUntil: "load" });
+            expect(response, `no response for ${route}`).not.toBeNull();
+            expect(
+                response!.status(),
+                `${route} returned ${response!.status()}`,
+            ).toBeLessThan(400);
+
+            // `networkidle` never settles under Next dev (HMR socket), so give
+            // lazy assets a short, bounded settle instead.
+            await page.waitForTimeout(1200);
+
+            // Scroll through the page so `loading="lazy"` images below the fold
+            // actually start loading before we inspect them, then return to top.
+            await page.evaluate(async () => {
+                const step = window.innerHeight;
+                for (let y = 0; y < document.body.scrollHeight; y += step) {
+                    window.scrollTo(0, y);
+                    await new Promise((r) => requestAnimationFrame(() => r(null)));
+                }
+                window.scrollTo(0, 0);
+            });
+            await page.waitForTimeout(800);
+
+            // Broken images: rendered <img> that failed to decode. Skip images
+            // still in flight (complete === false) to avoid false positives.
+            const brokenImages = await page.evaluate(() =>
+                Array.from(document.querySelectorAll("img"))
+                    .filter(
+                        (img) =>
+                            img.currentSrc &&
+                            img.complete &&
+                            img.naturalWidth === 0,
+                    )
+                    .map((img) => img.currentSrc),
+            );
+
+            await testInfo.attach("screenshot", {
+                body: await page.screenshot({ fullPage: true }),
+                contentType: "image/png",
+            });
+
+            expect(pageErrors, `uncaught JS errors on ${route}`).toEqual([]);
+            expect(consoleErrors, `console errors on ${route}`).toEqual([]);
+            expect(failedRequests, `failed requests on ${route}`).toEqual([]);
+            expect(brokenImages, `broken images on ${route}`).toEqual([]);
+        });
+    }
+});

--- a/apps/ncottage-www/next.config.ts
+++ b/apps/ncottage-www/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+    // Allow the dev server to be reached via 127.0.0.1 (used by Playwright)
+    // without the cross-origin _next/* warning.
+    allowedDevOrigins: ["127.0.0.1"],
     images: {
         remotePatterns: [
             {

--- a/apps/ncottage-www/package.json
+++ b/apps/ncottage-www/package.json
@@ -11,7 +11,9 @@
         "typecheck": "tsc --noEmit",
         "clean": "rm -rf .next out",
         "storybook": "storybook dev -p 6006",
-        "build-storybook": "storybook build"
+        "build-storybook": "storybook build",
+        "test:e2e": "playwright test",
+        "test:e2e:ui": "playwright test --ui"
     },
     "dependencies": {
         "next": "^15.3.1",
@@ -19,6 +21,7 @@
         "react-dom": "^19.1.0"
     },
     "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@storybook/nextjs": "^10.3.5",
         "@storybook/react": "^10.3.5",
         "@types/react": "^19.1.2",

--- a/apps/ncottage-www/playwright.config.ts
+++ b/apps/ncottage-www/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = Number(process.env.PORT ?? 3000);
+const BASE_URL = process.env.BASE_URL ?? `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+    testDir: "./e2e",
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    // Next dev compiles routes on first hit; one retry absorbs cold-compile
+    // timeouts without masking real failures (a real bug fails twice).
+    retries: process.env.CI ? 2 : 1,
+    workers: process.env.CI ? 2 : 4,
+    reporter: [["list"], ["html", { open: "never" }]],
+    timeout: 60_000,
+    expect: { timeout: 10_000 },
+    use: {
+        baseURL: BASE_URL,
+        navigationTimeout: 45_000,
+        actionTimeout: 15_000,
+        trace: "retain-on-failure",
+    },
+    projects: [
+        {
+            name: "desktop",
+            use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 900 } },
+        },
+        {
+            name: "mobile",
+            use: { ...devices["Pixel 5"] },
+        },
+    ],
+    webServer: {
+        command: "pnpm dev",
+        url: BASE_URL,
+        // In CI always start a clean server; locally reuse a running dev server.
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,7 @@ importers:
     dependencies:
       next:
         specifier: ^15.3.1
-        version: 15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 15.5.15(@babel/core@7.29.0)(@playwright/test@1.61.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.1.0
         version: 19.2.5
@@ -119,9 +119,12 @@ importers:
         specifier: ^19.1.0
         version: 19.2.5(react@19.2.5)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.0
+        version: 1.61.0
       '@storybook/nextjs':
         specifier: ^10.3.5
-        version: 10.3.5(next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
+        version: 10.3.5(next@15.5.15(@babel/core@7.29.0)(@playwright/test@1.61.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)
       '@storybook/react':
         specifier: ^10.3.5
         version: 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
@@ -1708,6 +1711,11 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17':
     resolution: {integrity: sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==}
@@ -3528,6 +3536,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4415,6 +4428,16 @@ packages:
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
     engines: {node: '>=14.16'}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -6944,6 +6967,10 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)':
     dependencies:
       ansi-html: 0.0.9
@@ -7079,7 +7106,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@storybook/nextjs@10.3.5(next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)':
+  '@storybook/nextjs@10.3.5(next@15.5.15(@babel/core@7.29.0)(@playwright/test@1.61.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.104.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
@@ -7103,7 +7130,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.104.1)
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.15(@babel/core@7.29.0)(@playwright/test@1.61.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.104.1)
       postcss: 8.5.9
       postcss-loader: 8.2.1(postcss@8.5.9)(typescript@5.9.3)(webpack@5.104.1)
@@ -9190,6 +9217,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9793,7 +9823,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@15.5.15(@babel/core@7.29.0)(@playwright/test@1.61.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
@@ -9811,6 +9841,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.15
       '@next/swc-win32-arm64-msvc': 15.5.15
       '@next/swc-win32-x64-msvc': 15.5.15
+      '@playwright/test': 1.61.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -10102,6 +10133,14 @@ snapshots:
   pkg-dir@7.0.0:
     dependencies:
       find-up: 6.3.0
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
Closes #93.

## Summary
- Add `@playwright/test` с route-crawling smoke-сьютом (`apps/ncottage-www/e2e/`): на каждой странице проверяются console-ошибки, необработанные JS-исключения, ответы 4xx/5xx и битые изображения — для desktop и mobile вьюпортов.
- Авто-обнаружение статических роутов из `src/app` плюс образцы динамических роутов (проекты, услуги, подборки, акции, блог).
- Подключён Playwright MCP-сервер (`.mcp.json`) для интерактивной проверки поведения в браузере.
- `allowedDevOrigins` в `next.config.ts` гасит cross-origin dev-warning при заходе через 127.0.0.1.
- Артефакты Playwright/MCP добавлены в `.gitignore`.

## Test plan
- [x] `pnpm --filter @forge/ncottage-www typecheck`
- [x] `pnpm --filter @forge/ncottage-www test:e2e` — 98/98 (49 роутов × desktop/mobile)
- [ ] Ревью