### PR TITLE
feat: Persist leads via ncottage-api and proxy the Next route

### DIFF
--- a/apps/ncottage-api/src/app.module.ts
+++ b/apps/ncottage-api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { AppController } from "./app.controller.js";
 import { validateEnv } from "./config/env.validation.js";
+import { LeadsModule } from "./leads/leads.module.js";
 import { PrismaModule } from "./prisma/prisma.module.js";
 
 @Module({
@@ -11,6 +12,7 @@ import { PrismaModule } from "./prisma/prisma.module.js";
             validate: validateEnv,
         }),
         PrismaModule,
+        LeadsModule,
     ],
     controllers: [AppController],
 })

--- a/apps/ncottage-api/src/leads/delivery/lead-delivery.port.ts
+++ b/apps/ncottage-api/src/leads/delivery/lead-delivery.port.ts
@@ -1,0 +1,7 @@
+import type { Lead } from "@prisma/client";
+
+// Seam под доставку лида во внешние системы (Telegram/email/CRM).
+// В MVP связан с NoopLeadDelivery; смена провайдера не трогает контроллер/сервис.
+export abstract class LeadDeliveryPort {
+    abstract deliver(lead: Lead): Promise<void>;
+}

--- a/apps/ncottage-api/src/leads/delivery/noop-lead-delivery.ts
+++ b/apps/ncottage-api/src/leads/delivery/noop-lead-delivery.ts
@@ -1,0 +1,20 @@
+import { Injectable, Logger } from "@nestjs/common";
+import type { Lead } from "@prisma/client";
+import { LeadDeliveryPort } from "./lead-delivery.port.js";
+
+function maskPhone(phone: string): string {
+    const digits = phone.replace(/\D/g, "");
+    if (digits.length < 4) return "***";
+    return `***${digits.slice(-4)}`;
+}
+
+@Injectable()
+export class NoopLeadDelivery extends LeadDeliveryPort {
+    private readonly logger = new Logger(NoopLeadDelivery.name);
+
+    async deliver(lead: Lead): Promise<void> {
+        this.logger.log(
+            `Lead ${lead.id} (${lead.source}) phone ${maskPhone(lead.phone)}`
+        );
+    }
+}

--- a/apps/ncottage-api/src/leads/dto/create-lead.dto.ts
+++ b/apps/ncottage-api/src/leads/dto/create-lead.dto.ts
@@ -1,0 +1,58 @@
+import {
+    IsBoolean,
+    IsIn,
+    IsOptional,
+    IsString,
+    Validate,
+    ValidatorConstraint,
+    type ValidatorConstraintInterface,
+} from "class-validator";
+import {
+    LEAD_SOURCES,
+    MIN_PHONE_DIGITS,
+    countPhoneDigits,
+} from "@forge/shared";
+import type { LeadRequest, LeadSource } from "@forge/shared";
+
+@ValidatorConstraint({ name: "phoneDigits", async: false })
+class PhoneDigitsConstraint implements ValidatorConstraintInterface {
+    validate(value: unknown): boolean {
+        return (
+            typeof value === "string" &&
+            countPhoneDigits(value) >= MIN_PHONE_DIGITS
+        );
+    }
+
+    defaultMessage(): string {
+        return `phone must contain at least ${MIN_PHONE_DIGITS} digits`;
+    }
+}
+
+export class CreateLeadDto implements LeadRequest {
+    @IsIn(LEAD_SOURCES)
+    source!: LeadSource;
+
+    @IsString()
+    @Validate(PhoneDigitsConstraint)
+    phone!: string;
+
+    @IsOptional()
+    @IsString()
+    name?: string;
+
+    @IsOptional()
+    @IsString()
+    comment?: string;
+
+    @IsOptional()
+    @IsString()
+    preferredTime?: string;
+
+    @IsOptional()
+    @IsString()
+    project?: string;
+
+    @IsOptional()
+    @IsBoolean()
+    consent?: boolean;
+}

--- a/apps/ncottage-api/src/leads/leads.controller.ts
+++ b/apps/ncottage-api/src/leads/leads.controller.ts
@@ -1,0 +1,14 @@
+import { Body, Controller, Post } from "@nestjs/common";
+import { CreateLeadDto } from "./dto/create-lead.dto.js";
+import { LeadsService } from "./leads.service.js";
+
+@Controller("leads")
+export class LeadsController {
+    constructor(private readonly leads: LeadsService) {}
+
+    @Post()
+    async create(@Body() dto: CreateLeadDto) {
+        await this.leads.create(dto);
+        return { ok: true };
+    }
+}

--- a/apps/ncottage-api/src/leads/leads.module.ts
+++ b/apps/ncottage-api/src/leads/leads.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { LeadsController } from "./leads.controller.js";
+import { LeadsService } from "./leads.service.js";
+import { LeadDeliveryPort } from "./delivery/lead-delivery.port.js";
+import { NoopLeadDelivery } from "./delivery/noop-lead-delivery.js";
+
+@Module({
+    controllers: [LeadsController],
+    providers: [
+        LeadsService,
+        { provide: LeadDeliveryPort, useClass: NoopLeadDelivery },
+    ],
+})
+export class LeadsModule {}

--- a/apps/ncottage-api/src/leads/leads.service.ts
+++ b/apps/ncottage-api/src/leads/leads.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from "@nestjs/common";
+import type { Lead } from "@prisma/client";
+import { PrismaService } from "../prisma/prisma.service.js";
+import { CreateLeadDto } from "./dto/create-lead.dto.js";
+import { LeadDeliveryPort } from "./delivery/lead-delivery.port.js";
+
+@Injectable()
+export class LeadsService {
+    private readonly logger = new Logger(LeadsService.name);
+
+    constructor(
+        private readonly prisma: PrismaService,
+        private readonly delivery: LeadDeliveryPort
+    ) {}
+
+    async create(dto: CreateLeadDto): Promise<Lead> {
+        const lead = await this.prisma.lead.create({
+            data: {
+                source: dto.source,
+                phone: dto.phone,
+                name: dto.name,
+                comment: dto.comment,
+                preferredTime: dto.preferredTime,
+                project: dto.project,
+                consent: dto.consent,
+            },
+        });
+        // Доставка асинхронна и не блокирует ответ: лид уже сохранён.
+        void this.dispatch(lead);
+        return lead;
+    }
+
+    private async dispatch(lead: Lead): Promise<void> {
+        try {
+            await this.delivery.deliver(lead);
+            await this.prisma.lead.update({
+                where: { id: lead.id },
+                data: { deliveredAt: new Date() },
+            });
+        } catch (error) {
+            const message =
+                error instanceof Error ? error.message : String(error);
+            this.logger.error(`Lead ${lead.id} delivery failed: ${message}`);
+            await this.prisma.lead
+                .update({
+                    where: { id: lead.id },
+                    data: { deliveryError: message },
+                })
+                .catch(() => undefined);
+        }
+    }
+}

--- a/apps/ncottage-api/tsconfig.json
+++ b/apps/ncottage-api/tsconfig.json
@@ -4,11 +4,14 @@
         "module": "CommonJS",
         "moduleResolution": "node",
         "outDir": "./dist",
-        "rootDir": "./src",
         "incremental": true,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
-        "noEmit": false
+        "noEmit": false,
+        // paths:{} отменяет унаследованный @forge/* → packages/*/src.
+        // Иначе SWC инлайнит исходный путь в require и рантайм падает.
+        // @forge/shared резолвится через node_modules (dist).
+        "paths": {}
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "dist", "test"]

--- a/apps/ncottage-www/.env.example
+++ b/apps/ncottage-www/.env.example
@@ -1,0 +1,3 @@
+# URL бэкенда ncottage-api (server-side only, без NEXT_PUBLIC_).
+# Используется прокси-роутом /api/leads. Если не задан — заявка пишется в лог.
+NCOTTAGE_API_URL=http://localhost:3002

--- a/apps/ncottage-www/package.json
+++ b/apps/ncottage-www/package.json
@@ -16,6 +16,7 @@
         "test:e2e:ui": "playwright test --ui"
     },
     "dependencies": {
+        "@forge/shared": "workspace:*",
         "next": "^15.3.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/apps/ncottage-www/src/app/api/leads/route.ts
+++ b/apps/ncottage-www/src/app/api/leads/route.ts
@@ -8,6 +8,22 @@ function maskPhone(phone: string): string {
     return `***${digits.slice(-4)}`;
 }
 
+// Server-side only. When unset, the route falls back to logging so a submitted
+// lead is never silently dropped (e.g. before the backend is deployed).
+const API_URL = process.env.NCOTTAGE_API_URL;
+
+function logFallback(lead: LeadRequest, reason: string) {
+    console.info("[lead] received (fallback)", {
+        reason,
+        source: lead.source,
+        name: lead.name,
+        phone: maskPhone(lead.phone),
+        project: lead.project,
+        preferredTime: lead.preferredTime,
+        hasComment: Boolean(lead.comment),
+    });
+}
+
 export async function POST(request: Request) {
     let body: unknown;
     try {
@@ -27,18 +43,42 @@ export async function POST(request: Request) {
         );
     }
 
-    // TODO(backend): forward the lead to CRM / email / queue once the backend
-    // exists. This handler is the single integration seam — only its body
-    // needs to change. Until then we log on the server so a submitted lead is
-    // never silently dropped in the browser.
-    console.info("[lead] received", {
-        source: lead.source,
-        name: lead.name,
-        phone: maskPhone(lead.phone),
-        project: lead.project,
-        preferredTime: lead.preferredTime,
-        hasComment: Boolean(lead.comment),
-    });
+    if (!API_URL) {
+        logFallback(lead, "NCOTTAGE_API_URL is not set");
+        return NextResponse.json({ ok: true });
+    }
+
+    let res: Response;
+    try {
+        res = await fetch(`${API_URL}/leads`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(lead),
+        });
+    } catch {
+        // Backend unreachable: keep the lead in the server log and let the
+        // user see success instead of failing the form.
+        logFallback(lead, "backend unreachable");
+        return NextResponse.json({ ok: true });
+    }
+
+    if (!res.ok) {
+        let message = "Не удалось отправить заявку. Попробуйте ещё раз.";
+        try {
+            const data: unknown = await res.json();
+            if (
+                data &&
+                typeof data === "object" &&
+                "error" in data &&
+                typeof (data as { error: unknown }).error === "string"
+            ) {
+                message = (data as { error: string }).error;
+            }
+        } catch {
+            // keep default message
+        }
+        return NextResponse.json({ error: message }, { status: res.status });
+    }
 
     return NextResponse.json({ ok: true });
 }

--- a/apps/ncottage-www/src/domain/lead.ts
+++ b/apps/ncottage-www/src/domain/lead.ts
@@ -1,34 +1,10 @@
-export type LeadSource = "contacts" | "callback" | "project" | "works";
-
-export interface LeadRequest {
-    source: LeadSource;
-    phone: string;
-    name?: string;
-    comment?: string;
-    preferredTime?: string;
-    project?: string;
-    consent?: boolean;
-}
-
-export const LEAD_SOURCES: LeadSource[] = [
-    "contacts",
-    "callback",
-    "project",
-    "works",
-];
-
-const MIN_PHONE_DIGITS = 10;
-
-export function countPhoneDigits(phone: string): number {
-    return phone.replace(/\D/g, "").length;
-}
-
-export function isValidLead(
-    lead: Partial<LeadRequest> | null
-): lead is LeadRequest {
-    if (!lead || typeof lead !== "object") return false;
-    if (typeof lead.phone !== "string") return false;
-    if (countPhoneDigits(lead.phone) < MIN_PHONE_DIGITS) return false;
-    if (!lead.source || !LEAD_SOURCES.includes(lead.source)) return false;
-    return true;
-}
+// Контракт лида живёт в @forge/shared, чтобы фронт, прокси-route и backend
+// использовали один источник правды. Реэкспорт сохраняет существующие
+// импорты `@/domain/lead` без изменений.
+export {
+    LEAD_SOURCES,
+    MIN_PHONE_DIGITS,
+    countPhoneDigits,
+    isValidLead,
+} from "@forge/shared";
+export type { LeadSource, LeadRequest } from "@forge/shared";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,9 @@
 export { renderTemplate } from "./template.js";
 export type { TemplateValue, TemplateValues } from "./template.js";
+export {
+    LEAD_SOURCES,
+    MIN_PHONE_DIGITS,
+    countPhoneDigits,
+    isValidLead,
+} from "./lead.js";
+export type { LeadSource, LeadRequest } from "./lead.js";

--- a/packages/shared/src/lead.ts
+++ b/packages/shared/src/lead.ts
@@ -1,0 +1,34 @@
+export type LeadSource = "contacts" | "callback" | "project" | "works";
+
+export interface LeadRequest {
+    source: LeadSource;
+    phone: string;
+    name?: string;
+    comment?: string;
+    preferredTime?: string;
+    project?: string;
+    consent?: boolean;
+}
+
+export const LEAD_SOURCES: LeadSource[] = [
+    "contacts",
+    "callback",
+    "project",
+    "works",
+];
+
+export const MIN_PHONE_DIGITS = 10;
+
+export function countPhoneDigits(phone: string): number {
+    return phone.replace(/\D/g, "").length;
+}
+
+export function isValidLead(
+    lead: Partial<LeadRequest> | null
+): lead is LeadRequest {
+    if (!lead || typeof lead !== "object") return false;
+    if (typeof lead.phone !== "string") return false;
+    if (countPhoneDigits(lead.phone) < MIN_PHONE_DIGITS) return false;
+    if (!lead.source || !LEAD_SOURCES.includes(lead.source)) return false;
+    return true;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
 
   apps/ncottage-www:
     dependencies:
+      '@forge/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       next:
         specifier: ^15.3.1
         version: 15.5.15(@babel/core@7.29.0)(@playwright/test@1.61.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
Closes #100.

## Summary
- Контракт лида (`LeadRequest`, `LEAD_SOURCES`, `countPhoneDigits`, `isValidLead`) вынесен в `@forge/shared` — единый источник для фронта, прокси и backend
- `apps/ncottage-www/src/domain/lead.ts` реэкспортит из `@forge/shared` (импорты `@/domain/lead` не тронуты); www получил зависимость `@forge/shared`
- `ncottage-api` `LeadsModule`: `POST /leads` с DTO-валидацией (class-validator), запись в БД
- `LeadDeliveryPort` + `NoopLeadDelivery` (маскированный лог) — seam под Telegram/email/CRM; `deliveredAt`/`deliveryError` на записи лида
- Next-route `/api/leads` → тонкий server-to-server прокси на `NCOTTAGE_API_URL`: пред-валидирует `isValidLead` (быстрый фидбэк, русские ошибки), при недоступности backend — fallback в маскированный лог (заявка не теряется). Клиентский `submitLead` не менялся

## Integration note
`@forge/shared` потребляется через node_modules: typecheck берёт типы из `src` (exports.types), build/runtime — `dist/index.js`. Пакет собирается топологически (`pnpm -r`), `transpilePackages`/path-хаки не понадобились.

## Test plan
- [x] `pnpm --filter @forge/ncottage-api typecheck` + `build`
- [x] `pnpm --filter @forge/ncottage-www typecheck` + `build` (статика собирается)
- [x] `pnpm --filter @forge/shared build`
- [x] `eslint` по затронутому
- [x] Рантайм API: короткий телефон / плохой source / лишнее поле → 400; валидный → доходит до Prisma (500 только из-за отсутствия БД)
- [ ] Запись лида в Postgres и сабмит формы на dev-www — не проверено локально (нет docker), проверить при поднятом Postgres
