### PR TITLE
feat: Add project content API and seed to ncottage-api

### DIFF
--- a/apps/ncottage-api/package.json
+++ b/apps/ncottage-api/package.json
@@ -4,7 +4,8 @@
     "private": true,
     "description": "ncottage backend: lead intake and content CMS",
     "prisma": {
-        "schema": "prisma/schema.prisma"
+        "schema": "prisma/schema.prisma",
+        "seed": "tsx prisma/seed.ts"
     },
     "scripts": {
         "dev": "nest start --watch",
@@ -16,7 +17,8 @@
         "clean": "rm -rf dist bundle",
         "prisma:generate": "prisma generate",
         "db:migrate": "prisma migrate dev",
-        "db:deploy": "prisma migrate deploy"
+        "db:deploy": "prisma migrate deploy",
+        "db:seed": "prisma db seed"
     },
     "dependencies": {
         "@forge/shared": "workspace:*",
@@ -39,6 +41,7 @@
         "esbuild": "^0.27.3",
         "prisma": "^6.7.0",
         "ts-node": "^10.9.2",
+        "tsx": "^4.20.0",
         "typescript": "^5.0.0"
     }
 }

--- a/apps/ncottage-api/prisma/seed-data/projects.json
+++ b/apps/ncottage-api/prisma/seed-data/projects.json
@@ -1,0 +1,509 @@
+[
+    {
+        "slug": "nord",
+        "name": "Норд",
+        "technology": "gas-concrete",
+        "area": 156,
+        "floors": 2,
+        "bedrooms": 4,
+        "bathrooms": 2,
+        "price": 4850000,
+        "image": "/images/projects/nord.jpg",
+        "images": [
+            "/images/projects/nord.jpg"
+        ],
+        "description": "Современный двухэтажный дом из газобетона с панорамными окнами и просторной террасой. Открытая планировка первого этажа объединяет кухню-гостиную с выходом на террасу — идеально для семейных вечеров. На втором этаже — четыре спальни и два санузла, что позволяет комфортно разместить семью с детьми и гостей.",
+        "specs": {
+            "dimensions": "10x13",
+            "roofType": "Двускатная",
+            "foundation": "Ленточный",
+            "wallMaterial": "Газобетон D400",
+            "buildTime": "4-5 месяцев"
+        },
+        "style": "modern",
+        "features": [
+            "panoramic-windows",
+            "terrace",
+            "second-light"
+        ],
+        "livingType": "permanent",
+        "featured": true,
+        "floorPlans": [
+            {
+                "label": "1 этаж",
+                "image": "/images/projects/nord.jpg",
+                "area": 78,
+                "rooms": [
+                    {
+                        "name": "Кухня-гостиная",
+                        "area": 34
+                    },
+                    {
+                        "name": "Холл и лестница",
+                        "area": 9
+                    },
+                    {
+                        "name": "Санузел",
+                        "area": 4
+                    },
+                    {
+                        "name": "Котельная",
+                        "area": 6
+                    },
+                    {
+                        "name": "Терраса",
+                        "area": 18
+                    }
+                ]
+            },
+            {
+                "label": "2 этаж",
+                "image": "/images/projects/nord.jpg",
+                "area": 78,
+                "rooms": [
+                    {
+                        "name": "Спальня хозяев",
+                        "area": 18
+                    },
+                    {
+                        "name": "Гардеробная",
+                        "area": 6
+                    },
+                    {
+                        "name": "Санузел",
+                        "area": 8
+                    },
+                    {
+                        "name": "Спальня",
+                        "area": 14
+                    },
+                    {
+                        "name": "Спальня",
+                        "area": 12
+                    },
+                    {
+                        "name": "Спальня",
+                        "area": 12
+                    }
+                ]
+            }
+        ],
+        "packages": [
+            {
+                "name": "Базовая",
+                "price": 4850000,
+                "tagline": "Тёплый контур",
+                "includes": [
+                    {
+                        "label": "Фундамент",
+                        "value": "Ленточный, армированный"
+                    },
+                    {
+                        "label": "Стены",
+                        "value": "Газобетон D400, 375 мм"
+                    },
+                    {
+                        "label": "Перекрытия",
+                        "value": "Монолит ж/б"
+                    },
+                    {
+                        "label": "Кровля",
+                        "value": "Металлочерепица"
+                    },
+                    {
+                        "label": "Окна",
+                        "value": "Не входит"
+                    },
+                    {
+                        "label": "Внутренняя отделка",
+                        "value": "Не входит"
+                    },
+                    {
+                        "label": "Инженерные сети",
+                        "value": "Не входит"
+                    }
+                ]
+            },
+            {
+                "name": "Стандарт",
+                "price": 5950000,
+                "tagline": "Под чистовую отделку",
+                "highlighted": true,
+                "includes": [
+                    {
+                        "label": "Фундамент",
+                        "value": "Ленточный, армированный"
+                    },
+                    {
+                        "label": "Стены",
+                        "value": "Газобетон D400, 375 мм"
+                    },
+                    {
+                        "label": "Перекрытия",
+                        "value": "Монолит ж/б"
+                    },
+                    {
+                        "label": "Кровля",
+                        "value": "Металлочерепица"
+                    },
+                    {
+                        "label": "Окна",
+                        "value": "Двухкамерные ПВХ"
+                    },
+                    {
+                        "label": "Внутренняя отделка",
+                        "value": "Черновая"
+                    },
+                    {
+                        "label": "Инженерные сети",
+                        "value": "Разводка"
+                    }
+                ]
+            },
+            {
+                "name": "Комфорт",
+                "price": 7400000,
+                "tagline": "Под ключ",
+                "includes": [
+                    {
+                        "label": "Фундамент",
+                        "value": "Ленточный, армированный"
+                    },
+                    {
+                        "label": "Стены",
+                        "value": "Газобетон D400, 375 мм"
+                    },
+                    {
+                        "label": "Перекрытия",
+                        "value": "Монолит ж/б"
+                    },
+                    {
+                        "label": "Кровля",
+                        "value": "Металлочерепица премиум"
+                    },
+                    {
+                        "label": "Окна",
+                        "value": "Двухкамерные ПВХ + откосы"
+                    },
+                    {
+                        "label": "Внутренняя отделка",
+                        "value": "Чистовая"
+                    },
+                    {
+                        "label": "Инженерные сети",
+                        "value": "Полностью"
+                    }
+                ]
+            }
+        ],
+        "options": [
+            {
+                "label": "Отделка фасада штукатуркой",
+                "price": 380000
+            },
+            {
+                "label": "Тёплый пол на 1 этаже",
+                "price": 240000
+            },
+            {
+                "label": "Камин в гостиной",
+                "price": 320000
+            },
+            {
+                "label": "Гараж 4×6 м, пристроенный",
+                "price": 690000
+            },
+            {
+                "label": "Расширенная терраса с навесом",
+                "price": 280000
+            }
+        ],
+        "relatedObjectIds": [
+            "nizhnie-oselki",
+            "severnaya-zhemchuzhina-2"
+        ],
+        "pdfUrl": "/projects/nord.pdf"
+    },
+    {
+        "slug": "alaster",
+        "name": "Аластер",
+        "technology": "brick",
+        "area": 210,
+        "floors": 2,
+        "bedrooms": 5,
+        "bathrooms": 3,
+        "price": 7200000,
+        "image": "/images/projects/alaster.jpg",
+        "images": [
+            "/images/projects/alaster.jpg"
+        ],
+        "description": "Классический кирпичный дом с мансардой, гаражом и вторым светом в гостиной. Просторная гостиная с двойной высотой потолков, отдельный кабинет, мастер-спальня с гардеробной и сан­узлом, четыре дополнительные спальни на мансардном этаже.",
+        "specs": {
+            "dimensions": "13x16",
+            "roofType": "Вальмовая",
+            "foundation": "Плитный",
+            "wallMaterial": "Кирпич",
+            "buildTime": "6-8 месяцев"
+        },
+        "style": "german",
+        "features": [
+            "attic",
+            "garage",
+            "second-light",
+            "terrace"
+        ],
+        "livingType": "permanent",
+        "featured": true,
+        "floorPlans": [
+            {
+                "label": "1 этаж",
+                "image": "/images/projects/alaster.jpg",
+                "area": 120,
+                "rooms": [
+                    {
+                        "name": "Гостиная (второй свет)",
+                        "area": 42
+                    },
+                    {
+                        "name": "Кухня-столовая",
+                        "area": 24
+                    },
+                    {
+                        "name": "Кабинет",
+                        "area": 12
+                    },
+                    {
+                        "name": "Санузел",
+                        "area": 5
+                    },
+                    {
+                        "name": "Гараж",
+                        "area": 24
+                    },
+                    {
+                        "name": "Терраса",
+                        "area": 16
+                    }
+                ]
+            },
+            {
+                "label": "Мансарда",
+                "image": "/images/projects/alaster.jpg",
+                "area": 90,
+                "rooms": [
+                    {
+                        "name": "Спальня хозяев",
+                        "area": 22
+                    },
+                    {
+                        "name": "Гардеробная",
+                        "area": 8
+                    },
+                    {
+                        "name": "Санузел при спальне",
+                        "area": 9
+                    },
+                    {
+                        "name": "Спальня",
+                        "area": 14
+                    },
+                    {
+                        "name": "Спальня",
+                        "area": 12
+                    },
+                    {
+                        "name": "Спальня",
+                        "area": 12
+                    },
+                    {
+                        "name": "Санузел",
+                        "area": 6
+                    }
+                ]
+            }
+        ],
+        "relatedObjectIds": [
+            "priyutino"
+        ],
+        "pdfUrl": "/projects/alaster.pdf"
+    },
+    {
+        "slug": "valter",
+        "name": "Вальтер",
+        "technology": "gas-concrete",
+        "area": 180,
+        "floors": 2,
+        "bedrooms": 4,
+        "bathrooms": 2,
+        "price": 5600000,
+        "image": "/images/projects/valter.jpg",
+        "images": [
+            "/images/projects/valter.jpg"
+        ],
+        "description": "Элегантный дом с плоской кровлей в стиле хай-тек. Большая терраса и второй свет.",
+        "specs": {
+            "dimensions": "12x14",
+            "roofType": "Плоская",
+            "foundation": "Монолитная плита",
+            "wallMaterial": "Газобетон D500",
+            "buildTime": "5-6 месяцев"
+        },
+        "style": "hi-tech",
+        "features": [
+            "panoramic-windows",
+            "second-light",
+            "terrace"
+        ],
+        "livingType": "permanent",
+        "featured": true
+    },
+    {
+        "slug": "eliot",
+        "name": "Элиот",
+        "technology": "frame",
+        "area": 120,
+        "floors": 1,
+        "bedrooms": 3,
+        "bathrooms": 1,
+        "price": 3200000,
+        "image": "/images/projects/eliot.jpg",
+        "images": [
+            "/images/projects/eliot.jpg"
+        ],
+        "description": "Компактный одноэтажный каркасный дом для постоянного проживания семьи из 3-4 человек.",
+        "specs": {
+            "dimensions": "10x12",
+            "roofType": "Двускатная",
+            "foundation": "Свайно-винтовой",
+            "wallMaterial": "Каркас + утеплитель 200мм",
+            "buildTime": "2-3 месяца"
+        },
+        "style": "finnish",
+        "features": [
+            "terrace"
+        ],
+        "livingType": "permanent",
+        "featured": true
+    },
+    {
+        "slug": "faust",
+        "name": "Фауст",
+        "technology": "frame",
+        "area": 95,
+        "floors": 1,
+        "bedrooms": 2,
+        "bathrooms": 1,
+        "price": 2400000,
+        "image": "/images/projects/faust.jpg",
+        "images": [
+            "/images/projects/faust.jpg"
+        ],
+        "description": "Уютный каркасный дом для загородного отдыха с открытой планировкой.",
+        "specs": {
+            "dimensions": "8x12",
+            "roofType": "Двускатная",
+            "foundation": "Свайно-винтовой",
+            "wallMaterial": "Каркас + утеплитель 150мм",
+            "buildTime": "2 месяца"
+        },
+        "style": "minimalism",
+        "features": [
+            "terrace",
+            "guest"
+        ],
+        "livingType": "seasonal",
+        "featured": false
+    },
+    {
+        "slug": "berg",
+        "name": "Берг",
+        "technology": "sip",
+        "area": 140,
+        "floors": 2,
+        "bedrooms": 4,
+        "bathrooms": 2,
+        "price": 3800000,
+        "image": "/images/projects/berg.jpg",
+        "images": [
+            "/images/projects/berg.jpg"
+        ],
+        "description": "Энергоэффективный дом из СИП-панелей с быстрой сборкой и отличной теплоизоляцией.",
+        "specs": {
+            "dimensions": "10x12",
+            "roofType": "Двускатная",
+            "foundation": "Ленточный",
+            "wallMaterial": "СИП-панели 174мм",
+            "buildTime": "2-3 месяца"
+        },
+        "style": "minimalism",
+        "features": [
+            "boiler-room",
+            "balcony"
+        ],
+        "livingType": "permanent",
+        "featured": true
+    },
+    {
+        "slug": "karl",
+        "name": "Карл",
+        "technology": "brick",
+        "area": 240,
+        "floors": 2,
+        "bedrooms": 5,
+        "bathrooms": 3,
+        "price": 8500000,
+        "image": "/images/projects/karl.jpg",
+        "images": [
+            "/images/projects/karl.jpg"
+        ],
+        "description": "Просторный кирпичный дом премиум-класса с бассейном и сауной.",
+        "specs": {
+            "dimensions": "14x18",
+            "roofType": "Многоскатная",
+            "foundation": "Монолитная плита",
+            "wallMaterial": "Кирпич + утеплитель",
+            "buildTime": "8-10 месяцев"
+        },
+        "style": "chalet",
+        "features": [
+            "garage",
+            "boiler-room",
+            "terrace",
+            "balcony",
+            "with-utilities",
+            "ready"
+        ],
+        "livingType": "permanent",
+        "featured": true
+    },
+    {
+        "slug": "otto",
+        "name": "Отто",
+        "technology": "gas-concrete",
+        "area": 130,
+        "floors": 1,
+        "bedrooms": 3,
+        "bathrooms": 2,
+        "price": 4100000,
+        "image": "/images/projects/otto.jpg",
+        "images": [
+            "/images/projects/otto.jpg"
+        ],
+        "description": "Одноэтажный дом из газобетона с панорамным остеклением и террасой.",
+        "specs": {
+            "dimensions": "12x11",
+            "roofType": "Плоская",
+            "foundation": "Ленточный",
+            "wallMaterial": "Газобетон D400",
+            "buildTime": "3-4 месяца"
+        },
+        "style": "minimalism",
+        "features": [
+            "panoramic-windows",
+            "terrace",
+            "bay-window"
+        ],
+        "livingType": "permanent",
+        "featured": false
+    }
+]

--- a/apps/ncottage-api/prisma/seed.ts
+++ b/apps/ncottage-api/prisma/seed.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Prisma, PrismaClient } from "@prisma/client";
+import type { Project } from "@forge/shared";
+
+const prisma = new PrismaClient();
+
+function toJson(
+    value: unknown
+): Prisma.InputJsonValue | typeof Prisma.JsonNull {
+    return value == null ? Prisma.JsonNull : (value as Prisma.InputJsonValue);
+}
+
+function toData(p: Project): Prisma.ProjectUncheckedCreateInput {
+    return {
+        slug: p.slug,
+        name: p.name,
+        technology: p.technology,
+        area: p.area,
+        floors: p.floors,
+        bedrooms: p.bedrooms,
+        bathrooms: p.bathrooms,
+        price: p.price,
+        image: p.image,
+        style: p.style,
+        livingType: p.livingType,
+        featured: p.featured,
+        description: p.description,
+        pdfUrl: p.pdfUrl ?? null,
+        images: p.images,
+        features: p.features,
+        relatedObjectIds: p.relatedObjectIds ?? [],
+        specs: toJson(p.specs),
+        floorPlans: toJson(p.floorPlans),
+        packages: toJson(p.packages),
+        options: toJson(p.options),
+    };
+}
+
+async function main() {
+    const file = resolve(__dirname, "seed-data/projects.json");
+    const projects = JSON.parse(readFileSync(file, "utf-8")) as Project[];
+
+    for (const project of projects) {
+        const data = toData(project);
+        await prisma.project.upsert({
+            where: { slug: project.slug },
+            create: data,
+            update: data,
+        });
+    }
+
+    console.log(`Seeded ${projects.length} projects`);
+}
+
+main()
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());

--- a/apps/ncottage-api/src/app.module.ts
+++ b/apps/ncottage-api/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppController } from "./app.controller.js";
 import { validateEnv } from "./config/env.validation.js";
 import { LeadsModule } from "./leads/leads.module.js";
 import { PrismaModule } from "./prisma/prisma.module.js";
+import { ProjectsModule } from "./projects/projects.module.js";
 
 @Module({
     imports: [
@@ -13,6 +14,7 @@ import { PrismaModule } from "./prisma/prisma.module.js";
         }),
         PrismaModule,
         LeadsModule,
+        ProjectsModule,
     ],
     controllers: [AppController],
 })

--- a/apps/ncottage-api/src/projects/dto/list-projects-query.dto.ts
+++ b/apps/ncottage-api/src/projects/dto/list-projects-query.dto.ts
@@ -1,0 +1,17 @@
+import { Transform } from "class-transformer";
+import { IsBoolean, IsOptional, IsString } from "class-validator";
+
+export class ListProjectsQueryDto {
+    @IsOptional()
+    @IsString()
+    technology?: string;
+
+    @IsOptional()
+    @IsString()
+    livingType?: string;
+
+    @IsOptional()
+    @Transform(({ value }) => value === "true" || value === true)
+    @IsBoolean()
+    featured?: boolean;
+}

--- a/apps/ncottage-api/src/projects/projects.controller.ts
+++ b/apps/ncottage-api/src/projects/projects.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param, Query } from "@nestjs/common";
+import { ListProjectsQueryDto } from "./dto/list-projects-query.dto.js";
+import { ProjectsService } from "./projects.service.js";
+
+@Controller("projects")
+export class ProjectsController {
+    constructor(private readonly projects: ProjectsService) {}
+
+    @Get()
+    list(@Query() query: ListProjectsQueryDto) {
+        return this.projects.list(query);
+    }
+
+    @Get(":slug")
+    getOne(@Param("slug") slug: string) {
+        return this.projects.getBySlug(slug);
+    }
+}

--- a/apps/ncottage-api/src/projects/projects.module.ts
+++ b/apps/ncottage-api/src/projects/projects.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { ProjectsController } from "./projects.controller.js";
+import { ProjectsService } from "./projects.service.js";
+
+@Module({
+    controllers: [ProjectsController],
+    providers: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/apps/ncottage-api/src/projects/projects.service.ts
+++ b/apps/ncottage-api/src/projects/projects.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import type { Prisma, Project as ProjectRow } from "@prisma/client";
+import type { Project } from "@forge/shared";
+import { PrismaService } from "../prisma/prisma.service.js";
+
+export interface ListProjectsFilters {
+    technology?: string;
+    livingType?: string;
+    featured?: boolean;
+}
+
+function fromJson<T>(value: Prisma.JsonValue | null): T | undefined {
+    return value == null ? undefined : (value as unknown as T);
+}
+
+function toDomain(row: ProjectRow): Project {
+    return {
+        slug: row.slug,
+        name: row.name,
+        technology: row.technology as Project["technology"],
+        area: row.area,
+        floors: row.floors,
+        bedrooms: row.bedrooms,
+        bathrooms: row.bathrooms,
+        price: row.price,
+        image: row.image,
+        images: row.images,
+        description: row.description,
+        specs: row.specs as unknown as Project["specs"],
+        style: row.style as Project["style"],
+        features: row.features as Project["features"],
+        livingType: row.livingType as Project["livingType"],
+        featured: row.featured,
+        floorPlans: fromJson<Project["floorPlans"]>(row.floorPlans),
+        packages: fromJson<Project["packages"]>(row.packages),
+        options: fromJson<Project["options"]>(row.options),
+        relatedObjectIds: row.relatedObjectIds,
+        pdfUrl: row.pdfUrl ?? undefined,
+    };
+}
+
+@Injectable()
+export class ProjectsService {
+    constructor(private readonly prisma: PrismaService) {}
+
+    async list(filters: ListProjectsFilters): Promise<Project[]> {
+        const where: Prisma.ProjectWhereInput = {};
+        if (filters.technology) where.technology = filters.technology;
+        if (filters.livingType) where.livingType = filters.livingType;
+        if (filters.featured !== undefined) where.featured = filters.featured;
+
+        const rows = await this.prisma.project.findMany({
+            where,
+            orderBy: { createdAt: "asc" },
+        });
+        return rows.map(toDomain);
+    }
+
+    async getBySlug(slug: string): Promise<Project> {
+        const row = await this.prisma.project.findUnique({ where: { slug } });
+        if (!row) {
+            throw new NotFoundException(`Project not found: ${slug}`);
+        }
+        return toDomain(row);
+    }
+}

--- a/apps/ncottage-api/tsconfig.json
+++ b/apps/ncottage-api/tsconfig.json
@@ -13,6 +13,6 @@
         // @forge/shared резолвится через node_modules (dist).
         "paths": {}
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "prisma/seed.ts"],
     "exclude": ["node_modules", "dist", "test"]
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,3 +7,15 @@ export {
     isValidLead,
 } from "./lead.js";
 export type { LeadSource, LeadRequest } from "./lead.js";
+export type {
+    Technology,
+    ProjectStyle,
+    ProjectFeature,
+    ProjectLivingType,
+    ProjectSpecs,
+    ProjectFloorPlan,
+    ProjectPackage,
+    ProjectOption,
+    Project,
+    BuiltObject,
+} from "./project.js";

--- a/packages/shared/src/project.ts
+++ b/packages/shared/src/project.ts
@@ -1,0 +1,100 @@
+// Доменные типы проекта. Источник правды для backend (ncottage-api) и,
+// после переключения фронта (PR3b), для ncottage-www. Слаг-юнионы продублированы
+// из ncottage-www/src/domain/technology.ts; лейбл-мапы остаются на фронте (UI).
+
+export type Technology =
+    | "gas-concrete"
+    | "brick"
+    | "frame"
+    | "sip"
+    | "fachwerk"
+    | "foam-block"
+    | "modular"
+    | "combined";
+
+export type ProjectStyle =
+    | "modern"
+    | "finnish"
+    | "german"
+    | "loft"
+    | "chalet"
+    | "hi-tech"
+    | "minimalism";
+
+export type ProjectFeature =
+    | "panoramic-windows"
+    | "second-light"
+    | "guest"
+    | "with-utilities"
+    | "ready"
+    | "balcony"
+    | "bay-window"
+    | "boiler-room"
+    | "garage"
+    | "terrace"
+    | "attic";
+
+export type ProjectLivingType = "permanent" | "seasonal";
+
+export interface ProjectSpecs {
+    dimensions: string;
+    roofType: string;
+    foundation: string;
+    wallMaterial: string;
+    buildTime: string;
+}
+
+export interface ProjectFloorPlan {
+    label: string;
+    image: string;
+    area?: number;
+    rooms?: { name: string; area: number }[];
+}
+
+export interface ProjectPackage {
+    name: string;
+    price: number;
+    tagline?: string;
+    highlighted?: boolean;
+    includes: { label: string; value: string }[];
+}
+
+export interface ProjectOption {
+    label: string;
+    price: number;
+    note?: string;
+}
+
+export interface Project {
+    slug: string;
+    name: string;
+    technology: Technology;
+    area: number;
+    floors: number;
+    bedrooms: number;
+    bathrooms: number;
+    price: number;
+    image: string;
+    images: string[];
+    description: string;
+    specs: ProjectSpecs;
+    style: ProjectStyle;
+    features: ProjectFeature[];
+    livingType: ProjectLivingType;
+    featured: boolean;
+    floorPlans?: ProjectFloorPlan[];
+    packages?: ProjectPackage[];
+    options?: ProjectOption[];
+    relatedObjectIds?: string[];
+    pdfUrl?: string;
+}
+
+export interface BuiltObject {
+    id: string;
+    title: string;
+    image: string;
+    href: string;
+    area?: number;
+    location?: string;
+    coords?: { lat: number; lng: number };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.13)(@types/node@25.3.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.20.0
+        version: 4.22.4
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -867,6 +870,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -875,6 +884,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -891,6 +906,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -899,6 +920,12 @@ packages:
 
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -915,6 +942,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -923,6 +956,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -939,6 +978,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -947,6 +992,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -963,6 +1014,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -971,6 +1028,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -987,6 +1050,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -995,6 +1064,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1011,6 +1086,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -1019,6 +1100,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1035,6 +1122,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -1043,6 +1136,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1059,8 +1158,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1077,8 +1188,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1095,8 +1218,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1113,6 +1248,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -1121,6 +1262,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1137,6 +1284,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -1145,6 +1298,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3428,6 +3587,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -5485,6 +5649,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
 
@@ -6597,10 +6766,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -6609,10 +6784,16 @@ snapshots:
   '@esbuild/android-arm@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -6621,10 +6802,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -6633,10 +6820,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -6645,10 +6838,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -6657,10 +6856,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -6669,10 +6874,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -6681,10 +6892,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -6693,7 +6910,13 @@ snapshots:
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -6702,7 +6925,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -6711,7 +6940,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -6720,10 +6955,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -6732,10 +6973,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -9238,6 +9485,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -11631,6 +11907,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tty-browserify@0.0.1: {}
 


### PR DESCRIPTION
Closes #102.

## Summary
- Доменные типы проекта (`Project`, вложенные `ProjectSpecs/FloorPlan/Package/Option`, слаг-юнионы `Technology/ProjectStyle/ProjectFeature/ProjectLivingType`) вынесены в `@forge/shared`
- `ncottage-api` `ProjectsModule`: публичные `GET /projects` (фильтры `technology`/`livingType`/`featured`) и `GET /projects/:slug` (404). JSON-поля БД мапятся в доменный shape
- `prisma/seed.ts` + снапшот `prisma/seed-data/projects.json` (8 существующих проектов): идемпотентный `upsert` по slug. Команда `pnpm --filter @forge/ncottage-api db:seed`

## Scope
Это backend-часть CMS проектов (PR3a). Фронт **не тронут**: переключение `data/projects.ts` на fetch + ISR и адаптация потребителей — отдельной задачей (PR3b), т.к. её нельзя проверить без живого Postgres. `project-selections` остаются в коде (предикаты-функции).

## Test plan
- [x] `typecheck` api (вкл. seed) + www; `build` api; `build` shared
- [x] `eslint` api + shared
- [x] Рантайм: `GET /projects`, `?featured=true`, `/projects/:slug` доходят до Prisma (500 только без БД); `?bad=1` → 400
- [x] `tsx prisma/seed.ts` грузится, читает JSON и `@forge/shared`, доходит до `upsert` (падает только на connect)
- [ ] Реальный seed в Postgres и ответы с данными — не проверено локально (нет docker), проверить при поднятой БД: `db:migrate` → `db:seed` → `curl /projects`
