### PR TITLE
feat: Serve ncottage-www projects from the API with ISR

### DIFF
--- a/apps/ncottage-www/src/app/api/projects/route.ts
+++ b/apps/ncottage-www/src/app/api/projects/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { getProjects } from "@/data/projects";
+
+// Публичный список проектов для клиентских компонентов (например SiteSearch),
+// которым нужен доступ к каталогу на стороне браузера. Проксирует server-side
+// fetch к ncottage-api, не раскрывая NCOTTAGE_API_URL в клиент.
+export async function GET() {
+    const projects = await getProjects();
+    return NextResponse.json(projects);
+}

--- a/apps/ncottage-www/src/app/compare/CompareView.tsx
+++ b/apps/ncottage-www/src/app/compare/CompareView.tsx
@@ -7,7 +7,6 @@ import { Container } from "@/components/ui/Container";
 import { SectionHeading } from "@/components/ui/SectionHeading";
 import type { Project } from "@/domain/project";
 import { PROJECT_TECHNOLOGY_LABELS } from "@/domain/technology";
-import { getProjectBySlug } from "@/data/projects";
 import { formatPrice } from "@/lib/utils";
 import { useSelection } from "@/lib/selection";
 import styles from "./page.module.css";
@@ -42,10 +41,11 @@ const ROWS: { label: string; value: (project: Project) => string }[] = [
     },
 ];
 
-export function CompareView() {
+export function CompareView({ projects: allProjects }: { projects: Project[] }) {
     const { compare, removeCompare, clearCompare } = useSelection();
+    const bySlug = new Map(allProjects.map((project) => [project.slug, project]));
     const projects = compare
-        .map((slug) => getProjectBySlug(slug))
+        .map((slug) => bySlug.get(slug))
         .filter((project): project is Project => project !== undefined);
 
     const gridTemplateColumns = `minmax(140px, 200px) repeat(${projects.length}, minmax(200px, 1fr))`;

--- a/apps/ncottage-www/src/app/compare/page.tsx
+++ b/apps/ncottage-www/src/app/compare/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { getProjects } from "@/data/projects";
 import { CompareView } from "./CompareView";
 
 export const metadata: Metadata = {
@@ -8,6 +9,9 @@ export const metadata: Metadata = {
     alternates: { canonical: "/compare" },
 };
 
-export default function ComparePage() {
-    return <CompareView />;
+export const revalidate = 60;
+
+export default async function ComparePage() {
+    const projects = await getProjects();
+    return <CompareView projects={projects} />;
 }

--- a/apps/ncottage-www/src/app/favourites/FavouritesView.tsx
+++ b/apps/ncottage-www/src/app/favourites/FavouritesView.tsx
@@ -5,7 +5,7 @@ import { Breadcrumbs } from "@/components/ui/Breadcrumbs";
 import { Container } from "@/components/ui/Container";
 import { SectionHeading } from "@/components/ui/SectionHeading";
 import { ProductCard } from "@/components/shared/ProductCard";
-import { getProjectBySlug } from "@/data/projects";
+import type { Project } from "@/domain/project";
 import { useSelection } from "@/lib/selection";
 import styles from "./page.module.css";
 
@@ -15,11 +15,12 @@ const tips = [
     "сравнивайте технологии, комплектации и внешний вид домов",
 ];
 
-export function FavouritesView() {
+export function FavouritesView({ projects: allProjects }: { projects: Project[] }) {
     const { favorites, clearFavorites } = useSelection();
+    const bySlug = new Map(allProjects.map((project) => [project.slug, project]));
     const projects = favorites
-        .map((slug) => getProjectBySlug(slug))
-        .filter((project) => project !== undefined);
+        .map((slug) => bySlug.get(slug))
+        .filter((project): project is Project => project !== undefined);
 
     return (
         <section className={styles.page}>

--- a/apps/ncottage-www/src/app/favourites/page.tsx
+++ b/apps/ncottage-www/src/app/favourites/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { getProjects } from "@/data/projects";
 import { FavouritesView } from "./FavouritesView";
 
 export const metadata: Metadata = {
@@ -8,6 +9,9 @@ export const metadata: Metadata = {
     alternates: { canonical: "/favourites" },
 };
 
-export default function FavouritesPage() {
-    return <FavouritesView />;
+export const revalidate = 60;
+
+export default async function FavouritesPage() {
+    const projects = await getProjects();
+    return <FavouritesView projects={projects} />;
 }

--- a/apps/ncottage-www/src/app/page.tsx
+++ b/apps/ncottage-www/src/app/page.tsx
@@ -19,7 +19,7 @@ import { formatMonthYear } from "@/lib/utils";
 
 export default async function HomePage() {
     const home = await getHomeContent();
-    const featuredProjects = getFeaturedProjects();
+    const featuredProjects = await getFeaturedProjects();
     const builtObjects = getBuiltObjects();
     const featuredObject =
         builtObjects.find((o) => o.id === home.featuredProject.objectId) ??

--- a/apps/ncottage-www/src/app/project-selections/[slug]/page.tsx
+++ b/apps/ncottage-www/src/app/project-selections/[slug]/page.tsx
@@ -16,6 +16,8 @@ interface Props {
     params: Promise<{ slug: string }>;
 }
 
+export const revalidate = 60;
+
 export function generateStaticParams() {
     return PROJECT_SELECTIONS.map((selection) => ({ slug: selection.slug }));
 }
@@ -39,7 +41,8 @@ export default async function ProjectSelectionPage({ params }: Props) {
 
     if (!selection) notFound();
 
-    const projects = getProjects().filter(selection.filter);
+    const allProjects = await getProjects();
+    const projects = allProjects.filter(selection.filter);
     const minArea = projects.length
         ? Math.min(...projects.map((project) => project.area))
         : 0;

--- a/apps/ncottage-www/src/app/project-selections/page.tsx
+++ b/apps/ncottage-www/src/app/project-selections/page.tsx
@@ -14,8 +14,10 @@ export const metadata: Metadata = {
     alternates: { canonical: "/project-selections" },
 };
 
-export default function ProjectSelectionsPage() {
-    const projects = getProjects();
+export const revalidate = 60;
+
+export default async function ProjectSelectionsPage() {
+    const projects = await getProjects();
     const featuredSelections = PROJECT_SELECTIONS.slice(0, 3).map(
         (selection) => ({
             ...selection,

--- a/apps/ncottage-www/src/app/project/[slug]/page.tsx
+++ b/apps/ncottage-www/src/app/project/[slug]/page.tsx
@@ -34,13 +34,16 @@ interface Props {
     params: Promise<{ slug: string }>;
 }
 
+export const revalidate = 60;
+
 export async function generateStaticParams() {
-    return getProjects().map((p) => ({ slug: p.slug }));
+    const projects = await getProjects();
+    return projects.map((p) => ({ slug: p.slug }));
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const { slug } = await params;
-    const project = getProjectBySlug(slug);
+    const project = await getProjectBySlug(slug);
     if (!project) return { title: "Проект не найден" };
     return {
         title: `${project.name} — проект дома ${formatArea(project.area)} | Новый Коттедж`,
@@ -50,13 +53,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function ProjectPage({ params }: Props) {
     const { slug } = await params;
-    const project = getProjectBySlug(slug);
+    const project = await getProjectBySlug(slug);
     if (!project) notFound();
 
     const technologyCategory = PROJECT_HUB_CATEGORIES.find(
         (c) => c.technology === project.technology
     );
-    const allProjects = getProjects();
+    const allProjects = await getProjects();
     const similar = pickSimilarProjects(allProjects, project, 3);
     const builtObjects = getBuiltObjects();
     const showroomObjects = project.relatedObjectIds

--- a/apps/ncottage-www/src/app/projects/[category]/page.tsx
+++ b/apps/ncottage-www/src/app/projects/[category]/page.tsx
@@ -11,6 +11,8 @@ interface Props {
     params: Promise<{ category: string }>;
 }
 
+export const revalidate = 60;
+
 export function generateStaticParams() {
     return PROJECT_HUB_CATEGORIES.map((c) => ({ category: c.slug }));
 }
@@ -33,14 +35,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function CategoryPage({ params }: Props) {
     const { category } = await params;
 
-    if (getProjectBySlug(category)) {
+    if (await getProjectBySlug(category)) {
         redirect(`/project/${category}`);
     }
 
     const meta = findCategory(category);
     if (!meta) notFound();
 
-    const projects = getProjects();
+    const projects = await getProjects();
 
     return (
         <section className={styles.page}>

--- a/apps/ncottage-www/src/components/shared/ProductCard/ProductCard.stories.tsx
+++ b/apps/ncottage-www/src/components/shared/ProductCard/ProductCard.stories.tsx
@@ -1,6 +1,34 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import type { Project } from "@/domain/project";
 import { ProductCard } from "./ProductCard";
-import { PROJECTS } from "@/data/projects";
+
+// Статичная фикстура для Storybook: проекты теперь приходят из API,
+// поэтому стори не зависят от рантайм-данных.
+const sampleProject: Project = {
+    slug: "nord",
+    name: "Норд",
+    technology: "gas-concrete",
+    area: 156,
+    floors: 2,
+    bedrooms: 4,
+    bathrooms: 2,
+    price: 4850000,
+    image: "/images/projects/nord.jpg",
+    images: ["/images/projects/nord.jpg"],
+    description:
+        "Современный двухэтажный дом из газобетона с панорамными окнами и просторной террасой.",
+    specs: {
+        dimensions: "10x13",
+        roofType: "Двускатная",
+        foundation: "Ленточный",
+        wallMaterial: "Газобетон D400",
+        buildTime: "4-5 месяцев",
+    },
+    style: "modern",
+    features: ["panoramic-windows", "terrace", "second-light"],
+    livingType: "permanent",
+    featured: true,
+};
 
 const meta: Meta<typeof ProductCard> = {
     title: "Shared/ProductCard",
@@ -18,11 +46,11 @@ export default meta;
 type Story = StoryObj<typeof ProductCard>;
 
 export const Grid: Story = {
-    args: { project: PROJECTS[0], variant: "grid" },
+    args: { project: sampleProject, variant: "grid" },
 };
 
 export const List: Story = {
-    args: { project: PROJECTS[0], variant: "list" },
+    args: { project: sampleProject, variant: "list" },
     decorators: [
         (Story) => (
             <div style={{ width: 800 }}>
@@ -34,7 +62,7 @@ export const List: Story = {
 
 export const Premium: Story = {
     args: {
-        project: PROJECTS.find((p) => p.slug === "karl") ?? PROJECTS[0],
+        project: { ...sampleProject, slug: "karl", name: "Карл" },
         variant: "grid",
     },
 };

--- a/apps/ncottage-www/src/components/shared/SiteSearch/SiteSearch.tsx
+++ b/apps/ncottage-www/src/components/shared/SiteSearch/SiteSearch.tsx
@@ -15,7 +15,6 @@ import { useRouter } from "next/navigation";
 import { Container } from "@/components/ui/Container";
 import { CloseIcon, SearchIcon } from "@/components/ui/icons";
 import { ArrowRightGlyph } from "./icons";
-import { PROJECTS } from "@/data/projects";
 import {
     PROJECT_HUB_CATEGORIES,
     PROJECT_TECHNOLOGY_LABELS,
@@ -71,10 +70,25 @@ export function SiteSearch({
     placeholder = "Найти проект",
 }: SiteSearchProps) {
     const [query, setQuery] = useState("");
+    const [projects, setProjects] = useState<Project[]>([]);
     const inputRef = useRef<HTMLInputElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
     const router = useRouter();
     const labelId = useId();
+
+    // Каталог для поиска подгружаем один раз с публичного прокси-роута.
+    useEffect(() => {
+        let cancelled = false;
+        fetch("/api/projects")
+            .then((res) => (res.ok ? res.json() : []))
+            .then((data: Project[]) => {
+                if (!cancelled) setProjects(data);
+            })
+            .catch(() => undefined);
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
     useEffect(() => {
         if (!open) {
@@ -110,15 +124,14 @@ export function SiteSearch({
 
     const results = useMemo<Project[]>(() => {
         if (!trimmed) return [];
-        return PROJECTS.filter((p) => matchesQuery(p, trimmed)).slice(
-            0,
-            MAX_RESULTS
-        );
-    }, [trimmed]);
+        return projects
+            .filter((p) => matchesQuery(p, trimmed))
+            .slice(0, MAX_RESULTS);
+    }, [trimmed, projects]);
 
     const suggested = useMemo<Project[]>(
-        () => PROJECTS.filter((p) => p.featured).slice(0, SUGGESTED_COUNT),
-        []
+        () => projects.filter((p) => p.featured).slice(0, SUGGESTED_COUNT),
+        [projects]
     );
 
     const navItems = useMemo<Array<{ key: string; href: string }>>(() => {

--- a/apps/ncottage-www/src/data/projects.ts
+++ b/apps/ncottage-www/src/data/projects.ts
@@ -1,335 +1,41 @@
 import type { Project } from "@/domain/project";
 
-export const PROJECTS: Project[] = [
-    {
-        slug: "nord",
-        name: "Норд",
-        technology: "gas-concrete",
-        area: 156,
-        floors: 2,
-        bedrooms: 4,
-        bathrooms: 2,
-        price: 4850000,
-        image: "/images/projects/nord.jpg",
-        images: ["/images/projects/nord.jpg"],
-        description:
-            "Современный двухэтажный дом из газобетона с панорамными окнами и просторной террасой. Открытая планировка первого этажа объединяет кухню-гостиную с выходом на террасу — идеально для семейных вечеров. На втором этаже — четыре спальни и два санузла, что позволяет комфортно разместить семью с детьми и гостей.",
-        specs: {
-            dimensions: "10x13",
-            roofType: "Двускатная",
-            foundation: "Ленточный",
-            wallMaterial: "Газобетон D400",
-            buildTime: "4-5 месяцев",
-        },
-        style: "modern",
-        features: ["panoramic-windows", "terrace", "second-light"],
-        livingType: "permanent",
-        featured: true,
-        floorPlans: [
-            {
-                label: "1 этаж",
-                image: "/images/projects/nord.jpg",
-                area: 78,
-                rooms: [
-                    { name: "Кухня-гостиная", area: 34 },
-                    { name: "Холл и лестница", area: 9 },
-                    { name: "Санузел", area: 4 },
-                    { name: "Котельная", area: 6 },
-                    { name: "Терраса", area: 18 },
-                ],
-            },
-            {
-                label: "2 этаж",
-                image: "/images/projects/nord.jpg",
-                area: 78,
-                rooms: [
-                    { name: "Спальня хозяев", area: 18 },
-                    { name: "Гардеробная", area: 6 },
-                    { name: "Санузел", area: 8 },
-                    { name: "Спальня", area: 14 },
-                    { name: "Спальня", area: 12 },
-                    { name: "Спальня", area: 12 },
-                ],
-            },
-        ],
-        packages: [
-            {
-                name: "Базовая",
-                price: 4850000,
-                tagline: "Тёплый контур",
-                includes: [
-                    { label: "Фундамент", value: "Ленточный, армированный" },
-                    { label: "Стены", value: "Газобетон D400, 375 мм" },
-                    { label: "Перекрытия", value: "Монолит ж/б" },
-                    { label: "Кровля", value: "Металлочерепица" },
-                    { label: "Окна", value: "Не входит" },
-                    { label: "Внутренняя отделка", value: "Не входит" },
-                    { label: "Инженерные сети", value: "Не входит" },
-                ],
-            },
-            {
-                name: "Стандарт",
-                price: 5950000,
-                tagline: "Под чистовую отделку",
-                highlighted: true,
-                includes: [
-                    { label: "Фундамент", value: "Ленточный, армированный" },
-                    { label: "Стены", value: "Газобетон D400, 375 мм" },
-                    { label: "Перекрытия", value: "Монолит ж/б" },
-                    { label: "Кровля", value: "Металлочерепица" },
-                    { label: "Окна", value: "Двухкамерные ПВХ" },
-                    { label: "Внутренняя отделка", value: "Черновая" },
-                    { label: "Инженерные сети", value: "Разводка" },
-                ],
-            },
-            {
-                name: "Комфорт",
-                price: 7400000,
-                tagline: "Под ключ",
-                includes: [
-                    { label: "Фундамент", value: "Ленточный, армированный" },
-                    { label: "Стены", value: "Газобетон D400, 375 мм" },
-                    { label: "Перекрытия", value: "Монолит ж/б" },
-                    { label: "Кровля", value: "Металлочерепица премиум" },
-                    { label: "Окна", value: "Двухкамерные ПВХ + откосы" },
-                    { label: "Внутренняя отделка", value: "Чистовая" },
-                    { label: "Инженерные сети", value: "Полностью" },
-                ],
-            },
-        ],
-        options: [
-            { label: "Отделка фасада штукатуркой", price: 380000 },
-            { label: "Тёплый пол на 1 этаже", price: 240000 },
-            { label: "Камин в гостиной", price: 320000 },
-            { label: "Гараж 4×6 м, пристроенный", price: 690000 },
-            { label: "Расширенная терраса с навесом", price: 280000 },
-        ],
-        relatedObjectIds: ["nizhnie-oselki", "severnaya-zhemchuzhina-2"],
-        pdfUrl: "/projects/nord.pdf",
-    },
-    {
-        slug: "alaster",
-        name: "Аластер",
-        technology: "brick",
-        area: 210,
-        floors: 2,
-        bedrooms: 5,
-        bathrooms: 3,
-        price: 7200000,
-        image: "/images/projects/alaster.jpg",
-        images: ["/images/projects/alaster.jpg"],
-        description:
-            "Классический кирпичный дом с мансардой, гаражом и вторым светом в гостиной. Просторная гостиная с двойной высотой потолков, отдельный кабинет, мастер-спальня с гардеробной и сан­узлом, четыре дополнительные спальни на мансардном этаже.",
-        specs: {
-            dimensions: "13x16",
-            roofType: "Вальмовая",
-            foundation: "Плитный",
-            wallMaterial: "Кирпич",
-            buildTime: "6-8 месяцев",
-        },
-        style: "german",
-        features: ["attic", "garage", "second-light", "terrace"],
-        livingType: "permanent",
-        featured: true,
-        floorPlans: [
-            {
-                label: "1 этаж",
-                image: "/images/projects/alaster.jpg",
-                area: 120,
-                rooms: [
-                    { name: "Гостиная (второй свет)", area: 42 },
-                    { name: "Кухня-столовая", area: 24 },
-                    { name: "Кабинет", area: 12 },
-                    { name: "Санузел", area: 5 },
-                    { name: "Гараж", area: 24 },
-                    { name: "Терраса", area: 16 },
-                ],
-            },
-            {
-                label: "Мансарда",
-                image: "/images/projects/alaster.jpg",
-                area: 90,
-                rooms: [
-                    { name: "Спальня хозяев", area: 22 },
-                    { name: "Гардеробная", area: 8 },
-                    { name: "Санузел при спальне", area: 9 },
-                    { name: "Спальня", area: 14 },
-                    { name: "Спальня", area: 12 },
-                    { name: "Спальня", area: 12 },
-                    { name: "Санузел", area: 6 },
-                ],
-            },
-        ],
-        relatedObjectIds: ["priyutino"],
-        pdfUrl: "/projects/alaster.pdf",
-    },
-    {
-        slug: "valter",
-        name: "Вальтер",
-        technology: "gas-concrete",
-        area: 180,
-        floors: 2,
-        bedrooms: 4,
-        bathrooms: 2,
-        price: 5600000,
-        image: "/images/projects/valter.jpg",
-        images: ["/images/projects/valter.jpg"],
-        description:
-            "Элегантный дом с плоской кровлей в стиле хай-тек. Большая терраса и второй свет.",
-        specs: {
-            dimensions: "12x14",
-            roofType: "Плоская",
-            foundation: "Монолитная плита",
-            wallMaterial: "Газобетон D500",
-            buildTime: "5-6 месяцев",
-        },
-        style: "hi-tech",
-        features: ["panoramic-windows", "second-light", "terrace"],
-        livingType: "permanent",
-        featured: true,
-    },
-    {
-        slug: "eliot",
-        name: "Элиот",
-        technology: "frame",
-        area: 120,
-        floors: 1,
-        bedrooms: 3,
-        bathrooms: 1,
-        price: 3200000,
-        image: "/images/projects/eliot.jpg",
-        images: ["/images/projects/eliot.jpg"],
-        description:
-            "Компактный одноэтажный каркасный дом для постоянного проживания семьи из 3-4 человек.",
-        specs: {
-            dimensions: "10x12",
-            roofType: "Двускатная",
-            foundation: "Свайно-винтовой",
-            wallMaterial: "Каркас + утеплитель 200мм",
-            buildTime: "2-3 месяца",
-        },
-        style: "finnish",
-        features: ["terrace"],
-        livingType: "permanent",
-        featured: true,
-    },
-    {
-        slug: "faust",
-        name: "Фауст",
-        technology: "frame",
-        area: 95,
-        floors: 1,
-        bedrooms: 2,
-        bathrooms: 1,
-        price: 2400000,
-        image: "/images/projects/faust.jpg",
-        images: ["/images/projects/faust.jpg"],
-        description:
-            "Уютный каркасный дом для загородного отдыха с открытой планировкой.",
-        specs: {
-            dimensions: "8x12",
-            roofType: "Двускатная",
-            foundation: "Свайно-винтовой",
-            wallMaterial: "Каркас + утеплитель 150мм",
-            buildTime: "2 месяца",
-        },
-        style: "minimalism",
-        features: ["terrace", "guest"],
-        livingType: "seasonal",
-        featured: false,
-    },
-    {
-        slug: "berg",
-        name: "Берг",
-        technology: "sip",
-        area: 140,
-        floors: 2,
-        bedrooms: 4,
-        bathrooms: 2,
-        price: 3800000,
-        image: "/images/projects/berg.jpg",
-        images: ["/images/projects/berg.jpg"],
-        description:
-            "Энергоэффективный дом из СИП-панелей с быстрой сборкой и отличной теплоизоляцией.",
-        specs: {
-            dimensions: "10x12",
-            roofType: "Двускатная",
-            foundation: "Ленточный",
-            wallMaterial: "СИП-панели 174мм",
-            buildTime: "2-3 месяца",
-        },
-        style: "minimalism",
-        features: ["boiler-room", "balcony"],
-        livingType: "permanent",
-        featured: true,
-    },
-    {
-        slug: "karl",
-        name: "Карл",
-        technology: "brick",
-        area: 240,
-        floors: 2,
-        bedrooms: 5,
-        bathrooms: 3,
-        price: 8500000,
-        image: "/images/projects/karl.jpg",
-        images: ["/images/projects/karl.jpg"],
-        description:
-            "Просторный кирпичный дом премиум-класса с бассейном и сауной.",
-        specs: {
-            dimensions: "14x18",
-            roofType: "Многоскатная",
-            foundation: "Монолитная плита",
-            wallMaterial: "Кирпич + утеплитель",
-            buildTime: "8-10 месяцев",
-        },
-        style: "chalet",
-        features: [
-            "garage",
-            "boiler-room",
-            "terrace",
-            "balcony",
-            "with-utilities",
-            "ready",
-        ],
-        livingType: "permanent",
-        featured: true,
-    },
-    {
-        slug: "otto",
-        name: "Отто",
-        technology: "gas-concrete",
-        area: 130,
-        floors: 1,
-        bedrooms: 3,
-        bathrooms: 2,
-        price: 4100000,
-        image: "/images/projects/otto.jpg",
-        images: ["/images/projects/otto.jpg"],
-        description:
-            "Одноэтажный дом из газобетона с панорамным остеклением и террасой.",
-        specs: {
-            dimensions: "12x11",
-            roofType: "Плоская",
-            foundation: "Ленточный",
-            wallMaterial: "Газобетон D400",
-            buildTime: "3-4 месяца",
-        },
-        style: "minimalism",
-        features: ["panoramic-windows", "terrace", "bay-window"],
-        livingType: "permanent",
-        featured: false,
-    },
-];
+// Проекты приходят из backend ncottage-api. NCOTTAGE_API_URL — server-only.
+// ISR: ответы кешируются на REVALIDATE секунд и перегенерируются в фоне,
+// поэтому публичный сайт не зависит от аптайма API на каждый запрос.
+const API_URL = process.env.NCOTTAGE_API_URL;
+const REVALIDATE = 60;
 
-export function getProjects(): Project[] {
-    return PROJECTS;
+async function fetchProjects(query = ""): Promise<Project[]> {
+    if (!API_URL) return [];
+    const res = await fetch(`${API_URL}/projects${query}`, {
+        next: { revalidate: REVALIDATE },
+    });
+    if (!res.ok) {
+        throw new Error(`Failed to fetch projects: ${res.status}`);
+    }
+    return res.json() as Promise<Project[]>;
 }
 
-export function getFeaturedProjects(): Project[] {
-    return PROJECTS.filter((p) => p.featured);
+export async function getProjects(): Promise<Project[]> {
+    return fetchProjects();
 }
 
-export function getProjectBySlug(slug: string): Project | undefined {
-    return PROJECTS.find((p) => p.slug === slug);
+export async function getFeaturedProjects(): Promise<Project[]> {
+    return fetchProjects("?featured=true");
+}
+
+export async function getProjectBySlug(
+    slug: string
+): Promise<Project | undefined> {
+    if (!API_URL) return undefined;
+    const res = await fetch(
+        `${API_URL}/projects/${encodeURIComponent(slug)}`,
+        { next: { revalidate: REVALIDATE } }
+    );
+    if (res.status === 404) return undefined;
+    if (!res.ok) {
+        throw new Error(`Failed to fetch project ${slug}: ${res.status}`);
+    }
+    return res.json() as Promise<Project>;
 }

--- a/apps/ncottage-www/src/domain/project.ts
+++ b/apps/ncottage-www/src/domain/project.ts
@@ -1,76 +1,14 @@
-import type {
-    ProjectFeature,
-    ProjectLivingType,
-    ProjectStyle,
-    Technology,
-} from "./technology";
-
+// Доменные типы проекта живут в @forge/shared (общие с backend ncottage-api).
+// Реэкспорт сохраняет существующие импорты `@/domain/project`.
 export type {
+    Technology,
+    ProjectStyle,
     ProjectFeature,
     ProjectLivingType,
-    ProjectStyle,
-    Technology,
-} from "./technology";
-
-interface ProjectSpecs {
-    dimensions: string;
-    roofType: string;
-    foundation: string;
-    wallMaterial: string;
-    buildTime: string;
-}
-
-export interface ProjectFloorPlan {
-    label: string;
-    image: string;
-    area?: number;
-    rooms?: { name: string; area: number }[];
-}
-
-export interface ProjectPackage {
-    name: string;
-    price: number;
-    tagline?: string;
-    highlighted?: boolean;
-    includes: { label: string; value: string }[];
-}
-
-export interface ProjectOption {
-    label: string;
-    price: number;
-    note?: string;
-}
-
-export interface Project {
-    slug: string;
-    name: string;
-    technology: Technology;
-    area: number;
-    floors: number;
-    bedrooms: number;
-    bathrooms: number;
-    price: number;
-    image: string;
-    images: string[];
-    description: string;
-    specs: ProjectSpecs;
-    style: ProjectStyle;
-    features: ProjectFeature[];
-    livingType: ProjectLivingType;
-    featured: boolean;
-    floorPlans?: ProjectFloorPlan[];
-    packages?: ProjectPackage[];
-    options?: ProjectOption[];
-    relatedObjectIds?: string[];
-    pdfUrl?: string;
-}
-
-export interface BuiltObject {
-    id: string;
-    title: string;
-    image: string;
-    href: string;
-    area?: number;
-    location?: string;
-    coords?: { lat: number; lng: number };
-}
+    ProjectSpecs,
+    ProjectFloorPlan,
+    ProjectPackage,
+    ProjectOption,
+    Project,
+    BuiltObject,
+} from "@forge/shared";

--- a/apps/ncottage-www/src/domain/technology.ts
+++ b/apps/ncottage-www/src/domain/technology.ts
@@ -1,5 +1,19 @@
+import type {
+    ProjectFeature,
+    ProjectLivingType,
+    ProjectStyle,
+    Technology,
+} from "@forge/shared";
+
+export type {
+    ProjectFeature,
+    ProjectLivingType,
+    ProjectStyle,
+    Technology,
+} from "@forge/shared";
+
 interface TechnologyDef {
-    slug: string;
+    slug: Technology;
     label: string;
     pickerLabel: string;
     category: {
@@ -93,22 +107,11 @@ const TECHNOLOGIES = [
     },
 ] as const satisfies readonly TechnologyDef[];
 
-export type Technology = (typeof TECHNOLOGIES)[number]["slug"];
-
 export const PROJECT_TECHNOLOGY_LABELS: Record<Technology, string> =
     Object.fromEntries(TECHNOLOGIES.map((t) => [t.slug, t.label])) as Record<
         Technology,
         string
     >;
-
-export type ProjectStyle =
-    | "modern"
-    | "finnish"
-    | "german"
-    | "loft"
-    | "chalet"
-    | "hi-tech"
-    | "minimalism";
 
 export const PROJECT_STYLE_LABELS: Record<ProjectStyle, string> = {
     modern: "Модерн",
@@ -119,19 +122,6 @@ export const PROJECT_STYLE_LABELS: Record<ProjectStyle, string> = {
     "hi-tech": "Хай-тек",
     minimalism: "Минимализм",
 };
-
-export type ProjectFeature =
-    | "panoramic-windows"
-    | "second-light"
-    | "guest"
-    | "with-utilities"
-    | "ready"
-    | "balcony"
-    | "bay-window"
-    | "boiler-room"
-    | "garage"
-    | "terrace"
-    | "attic";
 
 export const PROJECT_FEATURE_LABELS: Record<ProjectFeature, string> = {
     "panoramic-windows": "С панорамными окнами",
@@ -146,8 +136,6 @@ export const PROJECT_FEATURE_LABELS: Record<ProjectFeature, string> = {
     terrace: "С террасой",
     attic: "С мансардой",
 };
-
-export type ProjectLivingType = "permanent" | "seasonal";
 
 export const PROJECT_LIVING_TYPE_LABELS: Record<ProjectLivingType, string> = {
     permanent: "Для постоянного проживания",


### PR DESCRIPTION
Closes #107.

## Summary
- `data/projects.ts` (`getProjects`/`getFeaturedProjects`/`getProjectBySlug`) теперь async-fetch к `ncottage-api` с ISR (`revalidate` 60s); статичный массив 8 проектов удалён (источник — БД)
- `domain/project.ts` и `domain/technology.ts` используют доменные типы из `@forge/shared` (лейбл-мапы и `TECHNOLOGIES` остаются на фронте)
- Серверные страницы (home, `project/[slug]`, `projects/[category]`, `project-selections` + `[slug]`) переведены на `await` + `export const revalidate`
- Клиентские: `FavouritesView`/`CompareView` получают проекты пропсами от своих server-страниц; `SiteSearch` грузит каталог через новый прокси-роут `/api/projects` (API URL остаётся server-side)
- `project-selections` фильтры-предикаты остаются в коде

## Test plan (проверено против локального Postgres + API)
- [x] `typecheck` / `eslint` www
- [x] `build` www: SSG `/project/*` и `/projects/*` сгенерированы из живого API, ISR-метки проставлены
- [x] prod-render: `/project/nord` → «Норд», home → featured (Норд, Карл), `/api/projects` → 8
- [x] Доменные типы едины с backend через `@forge/shared`

Закрывает MVP проектов (backend #103 + этот фронт).
