### PR TITLE
feat: Add ncottage-admin content management UI

### DIFF
--- a/apps/ncottage-admin/.env.example
+++ b/apps/ncottage-admin/.env.example
@@ -1,0 +1,3 @@
+# URL бэкенда ncottage-api (server-side only). Админка ходит к API только
+# с сервера (Bearer-токен из httpOnly cookie), поэтому без NEXT_PUBLIC_.
+NCOTTAGE_API_URL=http://localhost:3002

--- a/apps/ncottage-admin/.gitignore
+++ b/apps/ncottage-admin/.gitignore
@@ -1,0 +1,4 @@
+.next
+out
+.env
+next-env.d.ts

--- a/apps/ncottage-admin/next.config.ts
+++ b/apps/ncottage-admin/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/apps/ncottage-admin/package.json
+++ b/apps/ncottage-admin/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@forge/ncottage-admin",
+    "version": "0.0.0",
+    "private": true,
+    "description": "ncottage admin — content management UI",
+    "type": "module",
+    "scripts": {
+        "dev": "next dev -p 3003",
+        "build": "next build",
+        "start": "next start -p 3003",
+        "typecheck": "tsc --noEmit",
+        "clean": "rm -rf .next out"
+    },
+    "dependencies": {
+        "@forge/shared": "workspace:*",
+        "next": "^15.3.1",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+    },
+    "devDependencies": {
+        "@types/node": "^25.3.0",
+        "@types/react": "^19.1.2",
+        "@types/react-dom": "^19.1.2",
+        "typescript": "^5.9.3"
+    }
+}

--- a/apps/ncottage-admin/src/app/actions.ts
+++ b/apps/ncottage-admin/src/app/actions.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { apiLogin } from "@/lib/api";
+import { clearToken, setToken } from "@/lib/session";
+
+export interface LoginState {
+    error?: string;
+}
+
+export async function loginAction(
+    _prev: LoginState,
+    formData: FormData
+): Promise<LoginState> {
+    const email = String(formData.get("email") ?? "");
+    const password = String(formData.get("password") ?? "");
+    const result = await apiLogin(email, password);
+    if (!result) {
+        return { error: "Неверный email или пароль" };
+    }
+    await setToken(result.accessToken);
+    redirect("/projects");
+}
+
+export async function logoutAction(): Promise<void> {
+    await clearToken();
+    redirect("/login");
+}

--- a/apps/ncottage-admin/src/app/globals.css
+++ b/apps/ncottage-admin/src/app/globals.css
@@ -1,0 +1,150 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family:
+        system-ui,
+        -apple-system,
+        "Segoe UI",
+        Roboto,
+        sans-serif;
+    color: #1a1a1a;
+    background: #f5f5f7;
+}
+
+a {
+    color: #0a58ca;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.topbar {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 0.75rem 1.5rem;
+    background: #fff;
+    border-bottom: 1px solid #e3e3e6;
+}
+
+.topbar strong {
+    font-size: 1rem;
+}
+
+.topbar nav {
+    display: flex;
+    gap: 1rem;
+}
+
+.topbar form {
+    margin-left: auto;
+}
+
+.container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 1.5rem;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border: 1px solid #e3e3e6;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+th,
+td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #ededf0;
+    font-size: 0.9rem;
+    vertical-align: top;
+}
+
+th {
+    background: #fafafb;
+    font-weight: 600;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    margin-bottom: 0.9rem;
+}
+
+.field label {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #444;
+}
+
+input,
+select,
+textarea,
+button {
+    font: inherit;
+}
+
+input,
+select,
+textarea {
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #c9c9cf;
+    border-radius: 6px;
+    background: #fff;
+    width: 100%;
+}
+
+textarea {
+    min-height: 120px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.82rem;
+}
+
+button,
+.btn {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: #0a58ca;
+    color: #fff;
+    cursor: pointer;
+}
+
+button.secondary,
+.btn.secondary {
+    background: #fff;
+    color: #1a1a1a;
+    border-color: #c9c9cf;
+}
+
+button.danger {
+    background: #c0392b;
+}
+
+.grid2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 1rem;
+}
+
+.error {
+    color: #c0392b;
+    font-size: 0.85rem;
+    margin: 0.5rem 0;
+}
+
+.row-actions {
+    display: flex;
+    gap: 0.5rem;
+}

--- a/apps/ncottage-admin/src/app/layout.tsx
+++ b/apps/ncottage-admin/src/app/layout.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getToken } from "@/lib/session";
+import { logoutAction } from "./actions";
+import "./globals.css";
+
+export const metadata: Metadata = {
+    title: "ncottage admin",
+};
+
+export default async function RootLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    const token = await getToken();
+
+    return (
+        <html lang="ru">
+            <body>
+                {token && (
+                    <header className="topbar">
+                        <strong>ncottage admin</strong>
+                        <nav>
+                            <Link href="/projects">Проекты</Link>
+                            <Link href="/leads">Заявки</Link>
+                        </nav>
+                        <form action={logoutAction}>
+                            <button type="submit" className="secondary">
+                                Выйти
+                            </button>
+                        </form>
+                    </header>
+                )}
+                <main className="container">{children}</main>
+            </body>
+        </html>
+    );
+}

--- a/apps/ncottage-admin/src/app/leads/actions.ts
+++ b/apps/ncottage-admin/src/app/leads/actions.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { apiSend } from "@/lib/api";
+
+export async function updateLeadStatus(formData: FormData): Promise<void> {
+    const id = String(formData.get("id") ?? "");
+    const status = String(formData.get("status") ?? "");
+    await apiSend("PATCH", `/leads/${id}`, { status });
+    revalidatePath("/leads");
+}

--- a/apps/ncottage-admin/src/app/leads/page.tsx
+++ b/apps/ncottage-admin/src/app/leads/page.tsx
@@ -1,0 +1,81 @@
+import { apiGet } from "@/lib/api";
+import {
+    LEAD_STATUSES,
+    LEAD_STATUS_LABELS,
+    type Lead,
+} from "@/lib/types";
+import { updateLeadStatus } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(iso: string): string {
+    return new Date(iso).toLocaleString("ru-RU", {
+        dateStyle: "short",
+        timeStyle: "short",
+    });
+}
+
+export default async function LeadsPage() {
+    const leads = await apiGet<Lead[]>("/leads");
+
+    return (
+        <>
+            <h1>Заявки ({leads.length})</h1>
+            {leads.length === 0 ? (
+                <p>Заявок пока нет.</p>
+            ) : (
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Дата</th>
+                            <th>Источник</th>
+                            <th>Имя</th>
+                            <th>Телефон</th>
+                            <th>Комментарий</th>
+                            <th>Статус</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {leads.map((lead) => (
+                            <tr key={lead.id}>
+                                <td>{formatDate(lead.createdAt)}</td>
+                                <td>{lead.source}</td>
+                                <td>{lead.name ?? "—"}</td>
+                                <td>{lead.phone}</td>
+                                <td>{lead.comment ?? "—"}</td>
+                                <td>
+                                    <form
+                                        action={updateLeadStatus}
+                                        className="row-actions"
+                                    >
+                                        <input
+                                            type="hidden"
+                                            name="id"
+                                            value={lead.id}
+                                        />
+                                        <select
+                                            name="status"
+                                            defaultValue={lead.status}
+                                        >
+                                            {LEAD_STATUSES.map((s) => (
+                                                <option key={s} value={s}>
+                                                    {LEAD_STATUS_LABELS[s]}
+                                                </option>
+                                            ))}
+                                        </select>
+                                        <button
+                                            type="submit"
+                                            className="secondary"
+                                        >
+                                            ОК
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+        </>
+    );
+}

--- a/apps/ncottage-admin/src/app/login/page.tsx
+++ b/apps/ncottage-admin/src/app/login/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useActionState } from "react";
+import { loginAction, type LoginState } from "../actions";
+
+const initial: LoginState = {};
+
+export default function LoginPage() {
+    const [state, action, pending] = useActionState(loginAction, initial);
+
+    return (
+        <div style={{ maxWidth: 360, margin: "4rem auto" }}>
+            <h1>Вход в админку</h1>
+            <form action={action}>
+                <div className="field">
+                    <label htmlFor="email">Email</label>
+                    <input
+                        id="email"
+                        name="email"
+                        type="email"
+                        autoComplete="username"
+                        required
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="password">Пароль</label>
+                    <input
+                        id="password"
+                        name="password"
+                        type="password"
+                        autoComplete="current-password"
+                        required
+                    />
+                </div>
+                {state.error && <p className="error">{state.error}</p>}
+                <button type="submit" disabled={pending}>
+                    {pending ? "Вход…" : "Войти"}
+                </button>
+            </form>
+        </div>
+    );
+}

--- a/apps/ncottage-admin/src/app/page.tsx
+++ b/apps/ncottage-admin/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function HomePage() {
+    redirect("/projects");
+}

--- a/apps/ncottage-admin/src/app/projects/ProjectForm.tsx
+++ b/apps/ncottage-admin/src/app/projects/ProjectForm.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useActionState } from "react";
+import {
+    PROJECT_FEATURES,
+    PROJECT_LIVING_TYPES,
+    PROJECT_STYLES,
+    TECHNOLOGIES,
+    type Project,
+} from "@forge/shared";
+import type { ProjectFormState } from "./actions";
+
+type Action = (
+    state: ProjectFormState,
+    formData: FormData
+) => Promise<ProjectFormState>;
+
+const initialState: ProjectFormState = {};
+
+function json(value: unknown): string {
+    return value ? JSON.stringify(value, null, 2) : "";
+}
+
+export function ProjectForm({
+    action,
+    initial,
+    submitLabel,
+}: {
+    action: Action;
+    initial?: Project;
+    submitLabel: string;
+}) {
+    const [state, formAction, pending] = useActionState(action, initialState);
+    const p = initial;
+
+    return (
+        <form action={formAction}>
+            <div className="grid2">
+                <div className="field">
+                    <label htmlFor="slug">Slug</label>
+                    <input
+                        id="slug"
+                        name="slug"
+                        defaultValue={p?.slug}
+                        required
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="name">Название</label>
+                    <input
+                        id="name"
+                        name="name"
+                        defaultValue={p?.name}
+                        required
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="technology">Технология</label>
+                    <select
+                        id="technology"
+                        name="technology"
+                        defaultValue={p?.technology ?? TECHNOLOGIES[0]}
+                    >
+                        {TECHNOLOGIES.map((t) => (
+                            <option key={t} value={t}>
+                                {t}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className="field">
+                    <label htmlFor="style">Стиль</label>
+                    <select
+                        id="style"
+                        name="style"
+                        defaultValue={p?.style ?? PROJECT_STYLES[0]}
+                    >
+                        {PROJECT_STYLES.map((s) => (
+                            <option key={s} value={s}>
+                                {s}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className="field">
+                    <label htmlFor="livingType">Тип проживания</label>
+                    <select
+                        id="livingType"
+                        name="livingType"
+                        defaultValue={p?.livingType ?? PROJECT_LIVING_TYPES[0]}
+                    >
+                        {PROJECT_LIVING_TYPES.map((l) => (
+                            <option key={l} value={l}>
+                                {l}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className="field">
+                    <label htmlFor="price">Цена, ₽</label>
+                    <input
+                        id="price"
+                        name="price"
+                        type="number"
+                        defaultValue={p?.price}
+                        required
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="area">Площадь, м²</label>
+                    <input
+                        id="area"
+                        name="area"
+                        type="number"
+                        defaultValue={p?.area}
+                        required
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="floors">Этажей</label>
+                    <input
+                        id="floors"
+                        name="floors"
+                        type="number"
+                        defaultValue={p?.floors}
+                        required
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="bedrooms">Спален</label>
+                    <input
+                        id="bedrooms"
+                        name="bedrooms"
+                        type="number"
+                        defaultValue={p?.bedrooms}
+                        required
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="bathrooms">Санузлов</label>
+                    <input
+                        id="bathrooms"
+                        name="bathrooms"
+                        type="number"
+                        defaultValue={p?.bathrooms}
+                        required
+                    />
+                </div>
+            </div>
+
+            <div className="field">
+                <label htmlFor="image">Главное изображение (путь)</label>
+                <input
+                    id="image"
+                    name="image"
+                    defaultValue={p?.image}
+                    required
+                />
+            </div>
+
+            <div className="field">
+                <label htmlFor="images">
+                    Галерея (по одному пути в строке)
+                </label>
+                <textarea
+                    id="images"
+                    name="images"
+                    defaultValue={p?.images.join("\n")}
+                />
+            </div>
+
+            <div className="field">
+                <label htmlFor="description">Описание</label>
+                <textarea
+                    id="description"
+                    name="description"
+                    defaultValue={p?.description}
+                    style={{ fontFamily: "inherit" }}
+                    required
+                />
+            </div>
+
+            <fieldset className="field">
+                <legend>Особенности</legend>
+                {PROJECT_FEATURES.map((f) => (
+                    <label
+                        key={f}
+                        style={{
+                            display: "inline-flex",
+                            gap: "0.3rem",
+                            marginRight: "1rem",
+                            fontWeight: 400,
+                        }}
+                    >
+                        <input
+                            type="checkbox"
+                            name="features"
+                            value={f}
+                            defaultChecked={p?.features.includes(f)}
+                            style={{ width: "auto" }}
+                        />
+                        {f}
+                    </label>
+                ))}
+            </fieldset>
+
+            <label
+                style={{
+                    display: "inline-flex",
+                    gap: "0.4rem",
+                    margin: "0.5rem 0 1rem",
+                }}
+            >
+                <input
+                    type="checkbox"
+                    name="featured"
+                    defaultChecked={p?.featured}
+                    style={{ width: "auto" }}
+                />
+                Показывать на главной (featured)
+            </label>
+
+            <h3>Характеристики</h3>
+            <div className="grid2">
+                <div className="field">
+                    <label htmlFor="specs.dimensions">Габариты</label>
+                    <input
+                        id="specs.dimensions"
+                        name="specs.dimensions"
+                        defaultValue={p?.specs.dimensions}
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="specs.roofType">Кровля</label>
+                    <input
+                        id="specs.roofType"
+                        name="specs.roofType"
+                        defaultValue={p?.specs.roofType}
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="specs.foundation">Фундамент</label>
+                    <input
+                        id="specs.foundation"
+                        name="specs.foundation"
+                        defaultValue={p?.specs.foundation}
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="specs.wallMaterial">Материал стен</label>
+                    <input
+                        id="specs.wallMaterial"
+                        name="specs.wallMaterial"
+                        defaultValue={p?.specs.wallMaterial}
+                    />
+                </div>
+                <div className="field">
+                    <label htmlFor="specs.buildTime">Срок строительства</label>
+                    <input
+                        id="specs.buildTime"
+                        name="specs.buildTime"
+                        defaultValue={p?.specs.buildTime}
+                    />
+                </div>
+            </div>
+
+            <div className="field">
+                <label htmlFor="floorPlans">Планировки (JSON)</label>
+                <textarea
+                    id="floorPlans"
+                    name="floorPlans"
+                    defaultValue={json(p?.floorPlans)}
+                />
+            </div>
+            <div className="field">
+                <label htmlFor="packages">Комплектации (JSON)</label>
+                <textarea
+                    id="packages"
+                    name="packages"
+                    defaultValue={json(p?.packages)}
+                />
+            </div>
+            <div className="field">
+                <label htmlFor="options">Опции (JSON)</label>
+                <textarea
+                    id="options"
+                    name="options"
+                    defaultValue={json(p?.options)}
+                />
+            </div>
+
+            <div className="field">
+                <label htmlFor="relatedObjectIds">
+                    Связанные объекты (id по строкам)
+                </label>
+                <textarea
+                    id="relatedObjectIds"
+                    name="relatedObjectIds"
+                    defaultValue={p?.relatedObjectIds?.join("\n")}
+                />
+            </div>
+            <div className="field">
+                <label htmlFor="pdfUrl">PDF (путь)</label>
+                <input id="pdfUrl" name="pdfUrl" defaultValue={p?.pdfUrl} />
+            </div>
+
+            {state.error && <p className="error">{state.error}</p>}
+            <button type="submit" disabled={pending}>
+                {pending ? "Сохранение…" : submitLabel}
+            </button>
+        </form>
+    );
+}

--- a/apps/ncottage-admin/src/app/projects/[slug]/page.tsx
+++ b/apps/ncottage-admin/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+import type { Project } from "@forge/shared";
+import { apiGet } from "@/lib/api";
+import { updateProject } from "../actions";
+import { ProjectForm } from "../ProjectForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditProjectPage({
+    params,
+}: {
+    params: Promise<{ slug: string }>;
+}) {
+    const { slug } = await params;
+    const project = await apiGet<Project>(
+        `/projects/${encodeURIComponent(slug)}`
+    ).catch(() => undefined);
+    if (!project) notFound();
+
+    const action = updateProject.bind(null, slug);
+
+    return (
+        <>
+            <h1>Редактирование: {project.name}</h1>
+            <ProjectForm
+                action={action}
+                initial={project}
+                submitLabel="Сохранить"
+            />
+        </>
+    );
+}

--- a/apps/ncottage-admin/src/app/projects/actions.ts
+++ b/apps/ncottage-admin/src/app/projects/actions.ts
@@ -1,0 +1,121 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import type {
+    Project,
+    ProjectFeature,
+    ProjectLivingType,
+    ProjectStyle,
+    Technology,
+} from "@forge/shared";
+import { apiSend } from "@/lib/api";
+
+export interface ProjectFormState {
+    error?: string;
+}
+
+function lines(value: FormDataEntryValue | null): string[] {
+    return String(value ?? "")
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean);
+}
+
+function parseJsonField(value: FormDataEntryValue | null): unknown {
+    const text = String(value ?? "").trim();
+    if (!text) return undefined;
+    return JSON.parse(text);
+}
+
+function buildProject(formData: FormData): Project {
+    const optionalString = (key: string): string | undefined => {
+        const v = String(formData.get(key) ?? "").trim();
+        return v ? v : undefined;
+    };
+
+    return {
+        slug: String(formData.get("slug") ?? "").trim(),
+        name: String(formData.get("name") ?? "").trim(),
+        technology: String(formData.get("technology") ?? "") as Technology,
+        area: Number(formData.get("area")),
+        floors: Number(formData.get("floors")),
+        bedrooms: Number(formData.get("bedrooms")),
+        bathrooms: Number(formData.get("bathrooms")),
+        price: Number(formData.get("price")),
+        image: String(formData.get("image") ?? "").trim(),
+        images: lines(formData.get("images")),
+        description: String(formData.get("description") ?? "").trim(),
+        specs: {
+            dimensions: String(formData.get("specs.dimensions") ?? "").trim(),
+            roofType: String(formData.get("specs.roofType") ?? "").trim(),
+            foundation: String(formData.get("specs.foundation") ?? "").trim(),
+            wallMaterial: String(
+                formData.get("specs.wallMaterial") ?? ""
+            ).trim(),
+            buildTime: String(formData.get("specs.buildTime") ?? "").trim(),
+        },
+        style: String(formData.get("style") ?? "") as ProjectStyle,
+        features: formData.getAll("features").map(String) as ProjectFeature[],
+        livingType: String(
+            formData.get("livingType") ?? ""
+        ) as ProjectLivingType,
+        featured: formData.get("featured") === "on",
+        floorPlans: parseJsonField(
+            formData.get("floorPlans")
+        ) as Project["floorPlans"],
+        packages: parseJsonField(
+            formData.get("packages")
+        ) as Project["packages"],
+        options: parseJsonField(formData.get("options")) as Project["options"],
+        relatedObjectIds: lines(formData.get("relatedObjectIds")),
+        pdfUrl: optionalString("pdfUrl"),
+    };
+}
+
+export async function createProject(
+    _prev: ProjectFormState,
+    formData: FormData
+): Promise<ProjectFormState> {
+    let project: Project;
+    try {
+        project = buildProject(formData);
+    } catch {
+        return { error: "Проверьте JSON-поля (планировки/комплектации/опции)" };
+    }
+    const result = await apiSend("POST", "/projects", project);
+    if (!result.ok) {
+        return { error: result.error };
+    }
+    revalidatePath("/projects");
+    redirect("/projects");
+}
+
+export async function updateProject(
+    slug: string,
+    _prev: ProjectFormState,
+    formData: FormData
+): Promise<ProjectFormState> {
+    let project: Project;
+    try {
+        project = buildProject(formData);
+    } catch {
+        return { error: "Проверьте JSON-поля (планировки/комплектации/опции)" };
+    }
+    const result = await apiSend(
+        "PATCH",
+        `/projects/${encodeURIComponent(slug)}`,
+        project
+    );
+    if (!result.ok) {
+        return { error: result.error };
+    }
+    revalidatePath("/projects");
+    redirect("/projects");
+}
+
+export async function deleteProject(formData: FormData): Promise<void> {
+    const slug = String(formData.get("slug") ?? "");
+    await apiSend("DELETE", `/projects/${encodeURIComponent(slug)}`);
+    revalidatePath("/projects");
+}

--- a/apps/ncottage-admin/src/app/projects/new/page.tsx
+++ b/apps/ncottage-admin/src/app/projects/new/page.tsx
@@ -1,0 +1,11 @@
+import { createProject } from "../actions";
+import { ProjectForm } from "../ProjectForm";
+
+export default function NewProjectPage() {
+    return (
+        <>
+            <h1>Новый проект</h1>
+            <ProjectForm action={createProject} submitLabel="Создать" />
+        </>
+    );
+}

--- a/apps/ncottage-admin/src/app/projects/page.tsx
+++ b/apps/ncottage-admin/src/app/projects/page.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+import type { Project } from "@forge/shared";
+import { apiGet } from "@/lib/api";
+import { deleteProject } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+const priceFormatter = new Intl.NumberFormat("ru-RU");
+
+export default async function ProjectsPage() {
+    const projects = await apiGet<Project[]>("/projects");
+
+    return (
+        <>
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "1rem",
+                    marginBottom: "1rem",
+                }}
+            >
+                <h1 style={{ margin: 0 }}>Проекты ({projects.length})</h1>
+                <Link href="/projects/new" className="btn">
+                    + Новый проект
+                </Link>
+            </div>
+
+            <table>
+                <thead>
+                    <tr>
+                        <th>Название</th>
+                        <th>Slug</th>
+                        <th>Технология</th>
+                        <th>Площадь</th>
+                        <th>Цена</th>
+                        <th>На главной</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {projects.map((project) => (
+                        <tr key={project.slug}>
+                            <td>{project.name}</td>
+                            <td>{project.slug}</td>
+                            <td>{project.technology}</td>
+                            <td>{project.area} м²</td>
+                            <td>{priceFormatter.format(project.price)} ₽</td>
+                            <td>{project.featured ? "да" : "—"}</td>
+                            <td>
+                                <div className="row-actions">
+                                    <Link
+                                        href={`/projects/${project.slug}`}
+                                        className="btn secondary"
+                                    >
+                                        Изменить
+                                    </Link>
+                                    <form action={deleteProject}>
+                                        <input
+                                            type="hidden"
+                                            name="slug"
+                                            value={project.slug}
+                                        />
+                                        <button
+                                            type="submit"
+                                            className="danger"
+                                        >
+                                            Удалить
+                                        </button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </>
+    );
+}

--- a/apps/ncottage-admin/src/lib/api.ts
+++ b/apps/ncottage-admin/src/lib/api.ts
@@ -1,0 +1,72 @@
+import { getToken } from "./session";
+
+const API_URL = process.env.NCOTTAGE_API_URL ?? "http://localhost:3002";
+
+async function authHeaders(): Promise<Record<string, string>> {
+    const token = await getToken();
+    return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function apiGet<T>(path: string): Promise<T> {
+    const res = await fetch(`${API_URL}${path}`, {
+        headers: await authHeaders(),
+        cache: "no-store",
+    });
+    if (!res.ok) {
+        throw new Error(`GET ${path} failed: ${res.status}`);
+    }
+    return res.json() as Promise<T>;
+}
+
+export interface ApiResult {
+    ok: boolean;
+    status: number;
+    error?: string;
+}
+
+export async function apiSend(
+    method: "POST" | "PATCH" | "DELETE",
+    path: string,
+    body?: unknown
+): Promise<ApiResult> {
+    const res = await fetch(`${API_URL}${path}`, {
+        method,
+        headers: {
+            ...(await authHeaders()),
+            ...(body ? { "Content-Type": "application/json" } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        cache: "no-store",
+    });
+    if (res.ok) {
+        return { ok: true, status: res.status };
+    }
+    let error = `Запрос не выполнен (${res.status})`;
+    try {
+        const data: unknown = await res.json();
+        if (data && typeof data === "object" && "message" in data) {
+            const message = (data as { message: unknown }).message;
+            error = Array.isArray(message)
+                ? message.join(", ")
+                : String(message);
+        }
+    } catch {
+        // keep default
+    }
+    return { ok: false, status: res.status, error };
+}
+
+// Логин не требует токена и сам возвращает accessToken.
+export async function apiLogin(
+    email: string,
+    password: string
+): Promise<{ accessToken: string } | null> {
+    const res = await fetch(`${API_URL}/auth/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+        cache: "no-store",
+    });
+    if (!res.ok) return null;
+    return res.json() as Promise<{ accessToken: string }>;
+}

--- a/apps/ncottage-admin/src/lib/session.ts
+++ b/apps/ncottage-admin/src/lib/session.ts
@@ -1,0 +1,24 @@
+import { cookies } from "next/headers";
+
+export const TOKEN_COOKIE = "admin_token";
+
+export async function getToken(): Promise<string | undefined> {
+    const store = await cookies();
+    return store.get(TOKEN_COOKIE)?.value;
+}
+
+export async function setToken(token: string): Promise<void> {
+    const store = await cookies();
+    store.set(TOKEN_COOKIE, token, {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: process.env.NODE_ENV === "production",
+        maxAge: 60 * 60 * 12,
+    });
+}
+
+export async function clearToken(): Promise<void> {
+    const store = await cookies();
+    store.delete(TOKEN_COOKIE);
+}

--- a/apps/ncottage-admin/src/lib/types.ts
+++ b/apps/ncottage-admin/src/lib/types.ts
@@ -1,0 +1,24 @@
+export type LeadStatus = "new" | "contacted" | "archived";
+
+export const LEAD_STATUSES: LeadStatus[] = ["new", "contacted", "archived"];
+
+export const LEAD_STATUS_LABELS: Record<LeadStatus, string> = {
+    new: "Новая",
+    contacted: "В работе",
+    archived: "Архив",
+};
+
+export interface Lead {
+    id: string;
+    source: string;
+    phone: string;
+    name: string | null;
+    comment: string | null;
+    preferredTime: string | null;
+    project: string | null;
+    consent: boolean | null;
+    status: LeadStatus;
+    createdAt: string;
+    deliveredAt: string | null;
+    deliveryError: string | null;
+}

--- a/apps/ncottage-admin/src/middleware.ts
+++ b/apps/ncottage-admin/src/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { TOKEN_COOKIE } from "@/lib/session";
+
+export function middleware(req: NextRequest) {
+    const token = req.cookies.get(TOKEN_COOKIE)?.value;
+    const isLogin = req.nextUrl.pathname === "/login";
+
+    if (!token && !isLogin) {
+        return NextResponse.redirect(new URL("/login", req.url));
+    }
+    if (token && isLogin) {
+        return NextResponse.redirect(new URL("/projects", req.url));
+    }
+    return NextResponse.next();
+}
+
+export const config = {
+    matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/apps/ncottage-admin/tsconfig.json
+++ b/apps/ncottage-admin/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "jsx": "preserve",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "resolveJsonModule": true,
+        "allowJs": true,
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": true,
+        "incremental": true,
+        "isolatedModules": true,
+        "plugins": [{ "name": "next" }],
+        "paths": {
+            "@/*": ["./src/*"],
+            "react": ["./node_modules/@types/react"],
+            "react-dom": ["./node_modules/@types/react-dom"]
+        }
+    },
+    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+    "exclude": ["node_modules", ".next", "out"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,34 @@ importers:
         specifier: ^5.4.10
         version: 5.4.21(@types/node@25.3.0)(terser@5.46.0)
 
+  apps/ncottage-admin:
+    dependencies:
+      '@forge/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      next:
+        specifier: ^15.3.1
+        version: 15.5.15(@babel/core@7.29.0)(@playwright/test@1.61.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.1.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
+      '@types/react':
+        specifier: ^19.1.2
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.2
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   apps/ncottage-api:
     dependencies:
       '@forge/shared':


### PR DESCRIPTION
Closes #109.

## Summary
Новое приложение `apps/ncottage-admin` — своя админка контента поверх `ncottage-api`, ручные формы (без headless CMS / React Admin).
- Вход `/login` (JWT в httpOnly cookie), `middleware` охраняет все страницы
- Заявки `/leads`: список + смена статуса инлайн
- Проекты `/projects`: список, создание `/projects/new`, редактирование `/projects/[slug]`, удаление; вложенные структуры (планировки/комплектации/опции) редактируются как JSON-поля
- Все вызовы к API — server-side с Bearer из cookie (токен не попадает в браузер); мутации через server actions

## Test plan (проверено против локального Postgres + API)
- [x] `typecheck` / `eslint` / `build` admin
- [x] `/login` → 200; `/projects` без cookie → 307 на `/login`; `/login` с cookie → 307 на `/projects` (middleware)
- [x] С реальным токеном: `/projects` рендерит проекты (Норд, Карл), `/leads` рендерит заявки
- [x] Backend CRUD (#105) подтверждён ранее: POST/PATCH/DELETE /projects, PATCH /leads/:id

## Заметка
Вложенные структуры проекта редактируются как JSON (прагматичный MVP); полноценные nested-редакторы — отдельная итерация при необходимости.

Завершает MVP: backend (лиды + проекты) + публичный сайт на CMS + админка.
