### PR TITLE
fix: Bump apps/preview Next.js to 15.5.22

### DIFF
--- a/apps/preview/package-lock.json
+++ b/apps/preview/package-lock.json
@@ -8,7 +8,7 @@
             "name": "ncottage-preview",
             "version": "0.1.0",
             "dependencies": {
-                "next": "^15.5.4",
+                "next": "^15.5.22",
                 "react": "19.0.0",
                 "react-dom": "19.0.0"
             },
@@ -551,15 +551,15 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.4.tgz",
-            "integrity": "sha512-27SQhYp5QryzIT5uO8hq99C69eLQ7qkzkDPsk3N+GuS2XgOgoYEeOav7Pf8Tn4drECOVDsDg8oj+/DVy8qQL2A==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
+            "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA==",
             "license": "MIT"
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.4.tgz",
-            "integrity": "sha512-nopqz+Ov6uvorej8ndRX6HlxCYWCO3AHLfKK2TYvxoSB2scETOcfm/HSS3piPqc3A+MUgyHoqE6je4wnkjfrOA==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
+            "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
             "cpu": [
                 "arm64"
             ],
@@ -573,9 +573,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.4.tgz",
-            "integrity": "sha512-QOTCFq8b09ghfjRJKfb68kU9k2K+2wsC4A67psOiMn849K9ZXgCSRQr0oVHfmKnoqCbEmQWG1f2h1T2vtJJ9mA==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
+            "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
             "cpu": [
                 "x64"
             ],
@@ -589,9 +589,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.4.tgz",
-            "integrity": "sha512-eRD5zkts6jS3VfE/J0Kt1VxdFqTnMc3QgO5lFE5GKN3KDI/uUpSyK3CjQHmfEkYR4wCOl0R0XrsjpxfWEA++XA==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
+            "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
             "cpu": [
                 "arm64"
             ],
@@ -605,9 +605,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.4.tgz",
-            "integrity": "sha512-TOK7iTxmXFc45UrtKqWdZ1shfxuL4tnVAOuuJK4S88rX3oyVV4ZkLjtMT85wQkfBrOOvU55aLty+MV8xmcJR8A==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
+            "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
             "cpu": [
                 "arm64"
             ],
@@ -621,9 +621,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.4.tgz",
-            "integrity": "sha512-7HKolaj+481FSW/5lL0BcTkA4Ueam9SPYWyN/ib/WGAFZf0DGAN8frNpNZYFHtM4ZstrHZS3LY3vrwlIQfsiMA==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
+            "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
             "cpu": [
                 "x64"
             ],
@@ -637,9 +637,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.4.tgz",
-            "integrity": "sha512-nlQQ6nfgN0nCO/KuyEUwwOdwQIGjOs4WNMjEUtpIQJPR2NUfmGpW2wkJln1d4nJ7oUzd1g4GivH5GoEPBgfsdw==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
+            "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
             "cpu": [
                 "x64"
             ],
@@ -653,9 +653,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.4.tgz",
-            "integrity": "sha512-PcR2bN7FlM32XM6eumklmyWLLbu2vs+D7nJX8OAIoWy69Kef8mfiN4e8TUv2KohprwifdpFKPzIP1njuCjD0YA==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
+            "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
             "cpu": [
                 "arm64"
             ],
@@ -669,9 +669,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.4.tgz",
-            "integrity": "sha512-1ur2tSHZj8Px/KMAthmuI9FMp/YFusMMGoRNJaRZMOlSkgvLjzosSdQI0cJAKogdHl3qXUQKL9MGaYvKwA7DXg==",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
+            "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
             "cpu": [
                 "x64"
             ],
@@ -1320,13 +1320,12 @@
             }
         },
         "node_modules/next": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/next/-/next-15.5.4.tgz",
-            "integrity": "sha512-xH4Yjhb82sFYQfY3vbkJfgSDgXvBB6a8xPs9i35k6oZJRoQRihZH+4s9Yo2qsWpzBmZ3lPXaJ2KPXLfkvW4LnA==",
-            "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.",
+            "version": "15.5.22",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
+            "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "15.5.4",
+                "@next/env": "15.5.22",
                 "@swc/helpers": "0.5.15",
                 "caniuse-lite": "^1.0.30001579",
                 "postcss": "8.4.31",
@@ -1339,14 +1338,14 @@
                 "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "15.5.4",
-                "@next/swc-darwin-x64": "15.5.4",
-                "@next/swc-linux-arm64-gnu": "15.5.4",
-                "@next/swc-linux-arm64-musl": "15.5.4",
-                "@next/swc-linux-x64-gnu": "15.5.4",
-                "@next/swc-linux-x64-musl": "15.5.4",
-                "@next/swc-win32-arm64-msvc": "15.5.4",
-                "@next/swc-win32-x64-msvc": "15.5.4",
+                "@next/swc-darwin-arm64": "15.5.22",
+                "@next/swc-darwin-x64": "15.5.22",
+                "@next/swc-linux-arm64-gnu": "15.5.22",
+                "@next/swc-linux-arm64-musl": "15.5.22",
+                "@next/swc-linux-x64-gnu": "15.5.22",
+                "@next/swc-linux-x64-musl": "15.5.22",
+                "@next/swc-win32-arm64-msvc": "15.5.22",
+                "@next/swc-win32-x64-msvc": "15.5.22",
                 "sharp": "^0.34.3"
             },
             "peerDependencies": {

--- a/apps/preview/package.json
+++ b/apps/preview/package.json
@@ -9,7 +9,7 @@
         "lint": "next lint"
     },
     "dependencies": {
-        "next": "^15.5.4",
+        "next": "^15.5.22",
         "react": "19.0.0",
         "react-dom": "19.0.0"
     },


### PR DESCRIPTION
## Summary

Closes #118.

`apps/preview`: `next` **15.5.4 → 15.5.22** (патч CVE-2025-66478).

### Changes
- `apps/preview/package.json`
- `apps/preview/package-lock.json`

### Verify
- [x] `npm ls next` → `next@15.5.22`
- [x] `npm run build` — 149 static pages OK
- npm audit: remaining highs не про next (отдельно при желании)

## Test plan
- [x] `cd apps/preview && npm run build`
- [ ] `pnpm dev:preview` / `npm run dev` → `:4000`